### PR TITLE
adapt expose-host-xen-scheduler-granularity-in-xapi to xapi-1.249.10

### DIFF
--- a/SOURCES/xapi-1.249.10-expose-host-xen-scheduler-granularity-in-xapi.XCP-ng.patch
+++ b/SOURCES/xapi-1.249.10-expose-host-xen-scheduler-granularity-in-xapi.XCP-ng.patch
@@ -114,7 +114,7 @@ diff --git c/ocaml/xapi/xapi_globs.ml w/ocaml/xapi/xapi_globs.ml
 index 1962b3fee..fad44111f 100644
 --- c/ocaml/xapi/xapi_globs.ml
 +++ w/ocaml/xapi/xapi_globs.ml
-@@ -241,6 +241,8 @@ let tools_sr_pbd_device_config =
+@@ -253,6 +253,8 @@
 
  let create_tools_sr = ref false
 
@@ -123,10 +123,10 @@ index 1962b3fee..fad44111f 100644
  let default_template_key = "default_template"
 
  let base_template_name_key = "base_template_name"
-@@ -1105,6 +1107,10 @@ let other_options =
-     , Arg.Set create_tools_sr
-     , (fun () -> string_of_bool !create_tools_sr)
-     , "Indicates whether to create an SR for Tools ISOs" )
+@@ -1125,6 +1127,10 @@
+     , Arg.Set website_https_only
+     , (fun () -> string_of_bool !website_https_only)
+     , "Allow access to the internal website using HTTPS only (no HTTP)" )
 +  ; ( "allow-host-sched-gran-modification"
 +    , Arg.Set allow_host_sched_gran_modification
 +    , (fun () -> string_of_bool !allow_host_sched_gran_modification)

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -24,7 +24,7 @@ Patch1002: xapi-1.249.5-open-vxlan-port-for-sdn-controller.XCP-ng.patch
 Patch1003: xapi-1.249.3-create-plugged-vif-and-vbd-and-suspended-vm.XCP-ng.patch
 Patch1004: xapi-1.249.3-open-openflow-port.XCP-ng.patch
 Patch1005: xapi-1.249.3-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
-Patch1006: xapi-1.249.5-expose-host-xen-scheduler-granularity-in-xapi.XCP-ng.patch
+Patch1006: xapi-1.249.10-expose-host-xen-scheduler-granularity-in-xapi.XCP-ng.patch
 Patch1007: xapi-1.249.9-update-schema-hash.XCP-ng.patch
 Patch1008: xapi-1.249.9-fix-usb-device-reset.backport.patch
 
@@ -467,7 +467,8 @@ Coverage files from unit tests
 %endif
 
 %changelog
-* Thu Sep 02 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.2.49.10-1.1
+* Thu Sep 02 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.249.10-1.1
+- Adapt `expose-host-xen-scheduler-granularity-in-xapi` patch to 1.249.10
 - Sync with hotfix XS82E031
 - *** Upstream changelog ***
 - * Fri Jul 16 2021 Ben Anson <ben.anson@citrix.com> - 1.249.10-1

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -468,8 +468,8 @@ Coverage files from unit tests
 
 %changelog
 * Thu Sep 02 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.249.10-1.1
-- Adapt `expose-host-xen-scheduler-granularity-in-xapi` patch to 1.249.10
 - Sync with hotfix XS82E031
+- Adapt `expose-host-xen-scheduler-granularity-in-xapi` patch to 1.249.10
 - *** Upstream changelog ***
 - * Fri Jul 16 2021 Ben Anson <ben.anson@citrix.com> - 1.249.10-1
 - - CP-36827: Backport XSI-989


### PR DESCRIPTION
Signed-off-by: BenjiReis <benjamin.reis@vates.fr>