### PR TITLE
Fix web dir param and reenable web pages on port 80

### DIFF
--- a/SOURCES/xapi-1.249.10-fix-web-dir-parameter.XCP-ng.patch
+++ b/SOURCES/xapi-1.249.10-fix-web-dir-parameter.XCP-ng.patch
@@ -1,0 +1,48 @@
+From f2a7aed7ceec13a63e1126f3d0ebb8730b15c5df Mon Sep 17 00:00:00 2001
+From: Samuel Verschelde <stormi-xcp@ylix.fr>
+Date: Fri, 10 Sep 2021 12:35:33 +0200
+Subject: [PATCH] Fix handling of web-dir parameter
+
+The web-dir parameter is not taken into account in the definition of
+common_http_handlers' get_root handler, because !Xapi_globs.web_dir is
+evaluated once and for all when the module loads, before the
+configuration file is read.
+
+Turn common_http_handlers into a function so that it is evaluated when
+called.
+
+Backported from 8909814f812312014b3a386f97d20ff06d342d44
+
+Related to issue #4512
+
+Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>
+Co-authored-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ ocaml/xapi/xapi.ml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ocaml/xapi/xapi.ml b/ocaml/xapi/xapi.ml
+index 07d437700..85186bbe3 100644
+--- a/ocaml/xapi/xapi.ml
++++ b/ocaml/xapi/xapi.ml
+@@ -708,7 +708,7 @@ let master_only_http_handlers =
+     , Http_svr.BufIO remote_database_access_handler_v2 )
+   ]
+ 
+-let common_http_handlers =
++let common_http_handlers () =
+   [
+     ("get_services_xenops", Http_svr.FdIO Xapi_services.get_handler)
+   ; ("put_services_xenops", Http_svr.FdIO Xapi_services.put_handler)
+@@ -944,7 +944,7 @@ let server_init () =
+           ; ("Killing stray sparse_dd processes", [], Sparse_dd_wrapper.killall)
+           ; ( "Registering http handlers"
+             , []
+-            , fun () -> List.iter Xapi_http.add_handler common_http_handlers )
++            , fun () -> List.iter Xapi_http.add_handler (common_http_handlers ()) )
+           ; ( "Registering master-only http handlers"
+             , [Startup.OnlyMaster]
+             , fun () ->
+-- 
+2.30.2
+

--- a/SOURCES/xapi-1.249.10-reenable-http-webpage.XCP-ng.patch
+++ b/SOURCES/xapi-1.249.10-reenable-http-webpage.XCP-ng.patch
@@ -1,0 +1,19 @@
+XAPI 1.249.10 enforces HTTPS for serving files over HTTP, but this also
+causes 403 errors for many HTTPS requests due to a bug in xen-api-libs-transitional.
+
+A fix was already contributed upstream in xen-api-libs-transitional, but until
+it's included in a hotfix, we let HTTP enabled.
+
+Index: xapi-1.249.10/ocaml/xapi/xapi_globs.ml
+===================================================================
+--- xapi-1.249.10/ocaml/xapi/xapi_globs.ml
++++ xapi-1.249.10/ocaml/xapi/xapi_globs.ml	2021-11-16 15:25:52.505282640 +0100
+@@ -779,7 +779,7 @@
+ 
+ let web_dir = ref "/opt/xensource/www"
+ 
+-let website_https_only = ref true
++let website_https_only = ref false
+ 
+ let cluster_stack_root = ref "/usr/libexec/xapi/cluster-stack"
+ 

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -3,7 +3,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 1.249.10
-Release: 1.1%{?dist}
+Release: 1.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL+linking exception
 URL:  http://www.xen.org
@@ -27,6 +27,8 @@ Patch1005: xapi-1.249.3-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
 Patch1006: xapi-1.249.10-expose-host-xen-scheduler-granularity-in-xapi.XCP-ng.patch
 Patch1007: xapi-1.249.9-update-schema-hash.XCP-ng.patch
 Patch1008: xapi-1.249.9-fix-usb-device-reset.backport.patch
+Patch1009: xapi-1.249.10-fix-web-dir-parameter.XCP-ng.patch
+Patch1010: xapi-1.249.10-reenable-http-webpage.XCP-ng.patch
 
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
@@ -467,6 +469,10 @@ Coverage files from unit tests
 %endif
 
 %changelog
+* Mon Sep 13 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.249.10-1.2
+- Fix handling of web-dir parameter
+- Reenable access to the website on port 80, to avoid a regression
+
 * Thu Sep 02 2021 Samuel Verschelde <stormi-xcp@ylix.fr> - 1.249.10-1.1
 - Sync with hotfix XS82E031
 - Adapt `expose-host-xen-scheduler-granularity-in-xapi` patch to 1.249.10


### PR DESCRIPTION
- Fix the web-dir parameter in xapi.conf. It was not taken into account.
- Disabling web pages on port 80 causes bogus 403 errors in HTTPS too, so
  we wait for the fix that we contributed upstream to be included in a
  hotfix and thus let access to web pages on port 80 temporarily.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>