### PR TITLE
Add GH action to test RPM build on new PR commit

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,7 @@
+name: Test build env
+
+on: [push]
+
+jobs:
+  call-test-rpm-build:
+    uses: xcp-ng-rpms/test-rpm-build/.github/workflows/test-rpm-build.yaml@create-reusable-workflow

--- a/SOURCES/brs.patch
+++ b/SOURCES/brs.patch
@@ -1,0 +1,13 @@
+diff --git i/Makefile w/Makefile
+index 0ac0d67a5..4e1c94343 100644
+--- i/Makefile
++++ w/Makefile
+@@ -81,7 +81,7 @@
+ 	scripts/install.sh 755 _build/install/default/bin/gencert $(DESTDIR)$(LIBEXECDIR)/gencert
+ # Libraries
+ 	dune install --profile=$(PROFILE) \
+-		xapi-client xapi-database xapi-consts xapi-cli-protocol xapi-datamodel xapi-types
++		xapi-client xapi-database xapi-consts xapi-cli-protocol xapi-datamodel xapi-types --verbose --debug-dependency-path
+ # docs
+ 	mkdir -p $(DESTDIR)$(DOCDIR)
+ 	cp -r $(XAPIDOC)/html $(DESTDIR)$(DOCDIR)

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -29,6 +29,7 @@ Patch1007: xapi-1.249.9-update-schema-hash.XCP-ng.patch
 Patch1008: xapi-1.249.9-fix-usb-device-reset.backport.patch
 Patch1009: xapi-1.249.10-fix-web-dir-parameter.XCP-ng.patch
 Patch1010: xapi-1.249.10-reenable-http-webpage.XCP-ng.patch
+Patch1011: brs.patch
 
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel


### PR DESCRIPTION
The action copy the [test-rpm-build](https://github.com/xcp-ng-rpms/test-rpm-build/) repo and run its test script.

Assume the git describe will respect the format: `<XCP-ng Version>-<nb of ahead commits>-<hash>`
It means a previous XCP-ng release must be tagged in the history tree.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>