### PR TITLE
quicktest: Add vdi_update filter to some tests

### DIFF
--- a/SOURCES/xapi-1.249.32-add-vdi_update-filter-to-some-tests.backport.patch
+++ b/SOURCES/xapi-1.249.32-add-vdi_update-filter-to-some-tests.backport.patch
@@ -1,0 +1,61 @@
+From 02f6766f8a2b7024d98de45ca4df2dbb52b05bc1 Mon Sep 17 00:00:00 2001
+From: BenjiReis <benjamin.reis@vates.fr>
+Date: Wed, 2 Aug 2023 13:07:19 +0200
+Subject: [PATCH] Add `vdi_update` filter to some tests
+
+These tests call at some point `VDI.update` so
+the VDIs not supporting it should be filtered out.
+
+Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ ocaml/quicktest/quicktest_cbt.ml | 2 ++
+ ocaml/quicktest/quicktest_vdi.ml | 6 ++++--
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/ocaml/quicktest/quicktest_cbt.ml b/ocaml/quicktest/quicktest_cbt.ml
+index afc5957ad..3c8a9a9cd 100644
+--- a/ocaml/quicktest/quicktest_cbt.ml
++++ b/ocaml/quicktest/quicktest_cbt.ml
+@@ -157,6 +157,7 @@ let tests () =
+                 ; `vdi_data_destroy
+                 ; `vdi_snapshot
+                 ]
++           |> has_capabilities [Sr_capabilities.vdi_update]
+          )
+   ; [("vdi_clone_copy_test", `Slow, vdi_clone_copy_test)]
+     |> conn
+@@ -165,6 +166,7 @@ let tests () =
+            all
+            |> allowed_operations
+                 [`vdi_create; `vdi_destroy; `vdi_enable_cbt; `vdi_clone]
++           |> has_capabilities [Sr_capabilities.vdi_update]
+          )
+   ]
+   |> List.concat
+diff --git a/ocaml/quicktest/quicktest_vdi.ml b/ocaml/quicktest/quicktest_vdi.ml
+index 5693b0d74..45a62eca7 100644
+--- a/ocaml/quicktest/quicktest_vdi.ml
++++ b/ocaml/quicktest/quicktest_vdi.ml
+@@ -407,7 +407,8 @@ let tests () =
+          )
+   ; [("test_vdi_snapshot", `Slow, test_vdi_snapshot)]
+     |> conn
+-    |> sr SR.(all |> has_capabilities [Sr_capabilities.vdi_snapshot])
++    |> sr
++         SR.(all |> has_capabilities Sr_capabilities.[vdi_snapshot; vdi_update])
+   ; [("test_vdi_clone", `Slow, test_vdi_clone)]
+     |> conn
+     |> sr
+@@ -418,7 +419,8 @@ let tests () =
+          )
+   ; [("vdi_snapshot_in_pool", `Slow, vdi_snapshot_in_pool)]
+     |> conn
+-    |> sr SR.(all |> has_capabilities [Sr_capabilities.vdi_snapshot])
++    |> sr
++         SR.(all |> has_capabilities Sr_capabilities.[vdi_snapshot; vdi_update])
+   ; [
+       ( "vdi_create_destroy_plug_checksize"
+       , `Slow
+-- 
+2.41.0
+

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -25,7 +25,8 @@ Patch1006: xapi-1.249.32-expose-host-xen-scheduler-granularity-in-xapi.XCP-ng.pa
 Patch1007: xapi-1.249.32-update-schema-hash.XCP-ng.patch
 # Contributed upstream, can be dropped in next version bump
 Patch1010: xapi-1.249.32-allow-a-user-to-select-on-which-SR-to-run-quicktest.backport.patch
-Patch1011: xapi-1.249.32-redirect-fileserver-https.backport.patch
+Patch1011: xapi-1.249.32-add-vdi_update-filter-to-some-tests.backport.patch
+Patch1012: xapi-1.249.32-redirect-fileserver-https.backport.patch
 
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
@@ -461,6 +462,7 @@ Coverage files from unit tests
 %changelog
 * Thu Aug 24 2023 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 1.249.32-1.2
 - Add xapi-1.249.32-allow-a-user-to-select-on-which-SR-to-run-quicktest.backport.patch
+- Add xapi-1.249.32-add-vdi_update-filter-to-some-tests.backport.patch
 - Remove xapi-1.249.32-fix-quicktest-default-sr-param.backport.patch
 
 * Wed Aug 09 2023 Gael Duperrey <gduperrey@vates.fr> - 1.249.32-1.1


### PR DESCRIPTION
This PR comes with https://github.com/xcp-ng-rpms/xapi/pull/46 so the release number is the same.