### PR TITLE
Adapt to new sources

### DIFF
--- a/SOURCES/xapi-24.11.0-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
+++ b/SOURCES/xapi-24.11.0-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
@@ -15,49 +15,51 @@ This patch will remain needed as long as we want to support such smooth transiti
 XCP-ng 8.2.
 
 diff --git i/ocaml/xapi/xapi_db_upgrade.ml w/ocaml/xapi/xapi_db_upgrade.ml
-index 2975f8851..9a6f8ed2e 100644
+index 05f20f083..3aaf3fead 100644
 --- i/ocaml/xapi/xapi_db_upgrade.ml
 +++ w/ocaml/xapi/xapi_db_upgrade.ml
-@@ -106,6 +106,9 @@ let jura =
+@@ -106,6 +106,10 @@ let jura =
    , Datamodel_common.jura_release_schema_minor_vsn
    )
 
 +let quebec =
-+    ( Datamodel_common.quebec_release_schema_major_vsn
-+    , Datamodel_common.quebec_release_schema_minor_vsn )
++  ( Datamodel_common.quebec_release_schema_major_vsn
++  , Datamodel_common.quebec_release_schema_minor_vsn )
++
  let yangtze =
    ( Datamodel_common.yangtze_release_schema_major_vsn
    , Datamodel_common.yangtze_release_schema_minor_vsn
-@@ -859,6 +862,25 @@ let empty_pool_uefi_certificates =
+@@ -904,6 +908,26 @@ let upgrade_update_guidance =
        )
    }
 
 +let fill_tunnel_protocol =
-+    {
-+      description=
-+        "Fill up the new field protocol of a Tunnel"
-+    ; version= (fun x -> x <= quebec)
-+    ; fn=
-+        (fun ~__context ->
-+          Db.Tunnel.get_all ~__context
-+          |> List.iter (fun self ->
-+            let pif = Db.Tunnel.get_access_PIF ~__context ~self in
-+            let network = Db.PIF.get_network ~__context ~self:pif in
-+            let other_config = Db.Network.get_other_config ~__context ~self:network in
-+            let encapsulation = List.assoc_opt "xo:sdn-controller:encapsulation" other_config
-+              |> Option.value ~default:"gre" in
-+            let value = Record_util.tunnel_protocol_of_string encapsulation in
-+            Db.Tunnel.set_protocol ~__context ~self ~value
-+          )
++  {
++    description=
++      "Fill up the new field protocol of a Tunnel"
++  ; version= (fun x -> x <= quebec)
++  ; fn=
++      (fun ~__context ->
++        Db.Tunnel.get_all ~__context
++        |> List.iter (fun self ->
++          let pif = Db.Tunnel.get_access_PIF ~__context ~self in
++          let network = Db.PIF.get_network ~__context ~self:pif in
++          let other_config = Db.Network.get_other_config ~__context ~self:network in
++          let encapsulation = List.assoc_opt "xo:sdn-controller:encapsulation" other_config
++            |> Option.value ~default:"gre" in
++          let value = Record_util.tunnel_protocol_of_string encapsulation in
++          Db.Tunnel.set_protocol ~__context ~self ~value
 +        )
-+    }
++      )
++  }
++
  let rules =
    [
      upgrade_domain_type
-@@ -887,6 +909,7 @@ let rules =
-   ; upgrade_secrets
+@@ -933,6 +957,7 @@ let rules =
    ; remove_legacy_ssl_support
    ; empty_pool_uefi_certificates
+   ; upgrade_update_guidance
 +  ; fill_tunnel_protocol
    ]
 

--- a/SOURCES/xapi-24.11.0-update-xapi-conf.XCP-ng.patch
+++ b/SOURCES/xapi-24.11.0-update-xapi-conf.XCP-ng.patch
@@ -1,26 +1,25 @@
-diff --git i/scripts/xapi.conf w/scripts/xapi.conf
-index 2f708e798..1084f025e 100644
---- i/scripts/xapi.conf
+diff --git c/scripts/xapi.conf w/scripts/xapi.conf
+index 46f859a8d..ddbf923f3 100644
+--- c/scripts/xapi.conf
 +++ w/scripts/xapi.conf
-@@ -1,3 +1,8 @@
+@@ -1,3 +1,7 @@
 +# WARNING: any changes made to this file may be overwritten by future
 +# updates of the xapi-core RPM.
 +# You may want to create a file in the /etc/xapi.conf.d/ directory instead
 +
-+
  # The xapi config file has 3 sections: a global policy section;
  # a section for paths to helper utilities; and a timeout tweak section.
 
-@@ -83,7 +88,7 @@ igd-passthru-vendor-whitelist = 8086
+@@ -82,7 +86,7 @@ igd-passthru-vendor-whitelist = 8086
+ # repository-domain-name-allowlist =
 
- # Override the default location of RPM-provided certificates in default_auth_dir (/usr/share/varstored)
- # to force use of customised UEFI certificates in varstore_dir (/var/lib/varstored)
--# override-uefi-certs = false
+ # Allow the use of custom UEFI certificates
+-# allow-custom-uefi-certs = false
 +allow-custom-uefi-certs = true
 
  # Paths to utilities: ############################################
 
-@@ -164,7 +169,7 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
+@@ -163,7 +167,7 @@ sparse_dd = /usr/libexec/xapi/sparse_dd
  # sm-dir =  @OPTDIR@/sm
 
  # Whitelist of SM plugins
@@ -29,7 +28,7 @@ index 2f708e798..1084f025e 100644
 
  # Directory containing tools ISO
  # tools-sr-dir = @OPTDIR@/packages/iso
-@@ -397,3 +402,12 @@ xen_livepatch_list = "/usr/sbin/xen-livepatch list"
+@@ -396,3 +400,12 @@ xen_livepatch_list = "/usr/sbin/xen-livepatch list"
 
  # The command to query current kernel patch list
  kpatch_list = "/usr/sbin/kpatch list"

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -57,21 +57,20 @@ Patch1: 0001-Xen-4.19-domctl_create_config.vmtrace_buf_kb.patch
 
 # XCP-ng patches
 # Enables our additional sm drivers
-Patch1000: xapi-23.31.0-update-xapi-conf.XCP-ng.patch
+Patch1000: xapi-24.11.0-update-xapi-conf.XCP-ng.patch
 # Patch1001: in XCP-ng xs-clipboardd is named xcp-clipboardd
 Patch1001: xenopsd-22.20.0-use-xcp-clipboardd.XCP-ng.patch
 # Replace this if/when PR https://github.com/xapi-project/xen-api/pull/4188 is finalized
 Patch1002: xapi-23.31.0-open-openflow-port.XCP-ng.patch
 # Drop this patch when we don't want to support migration from older SDN controller anymore
-Patch1003: xapi-23.24.0-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
+Patch1003: xapi-24.11.0-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
 # Needed for IPv6 support. Upstream wants a better fix. Drop when upstream fixed it.
 Patch1004: xapi-23.3.0-filter-link-local-address-ipv6.XCP-ng.patch
-Patch1005: xapi-23.31.0-extend-uefi-cert-api.patch
-Patch1006: xapi-23.31.0-fix-ipv6-import.XCP-ng.patch
-Patch1007: xapi-23.31.0-fix-ipv6-get-primary-address.XCP-ng.patch
+Patch1005: xapi-23.31.0-fix-ipv6-import.XCP-ng.patch
+Patch1006: xapi-23.31.0-fix-ipv6-get-primary-address.XCP-ng.patch
 # Upstream PR: https://github.com/xapi-project/xen-api/pull/5471
-Patch1008: xapi-23.31.0-xapi-service-depends-on-systemd-tmpfiles-setup.patch
-Patch1009: xapi-23.31.0-use-lib-guess-content-type.XCP-ng.patch
+Patch1007: xapi-23.31.0-xapi-service-depends-on-systemd-tmpfiles-setup.patch
+Patch1008: xapi-23.31.0-use-lib-guess-content-type.XCP-ng.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1386,9 +1385,11 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
-* next - 24.11.0-1.1
+* Wed Apr 10 2024 Benjamin Reis <benjamin.reis@vates.tech> - 24.11.0-1.1
 - Rebase on 24.11.0-1
-- TODO: Rediff patches
+- Drop xapi-23.31.0-extend-uefi-cert-api.patch
+- Rework xapi-24.11.0-update-xapi-conf.XCP-ng.patch
+- Rework xapi-24.11.0-update-db-tunnel-protocol-from-other_config.XCP-ng.patch
 - Rebase changelog on upstream changelog
 - *** Former XCP-ng 8.3 changelog ***
 - * Wed Apr 03 2024 Benjamin Reis <benjamin.reis@vates.tech> - 23.31.0-1.7


### PR DESCRIPTION
- Drop xapi-23.31.0-extend-uefi-cert-api.patch
- Rework xapi-24.11.0-update-xapi-conf.XCP-ng.patch
- Rework xapi-24.11.0-update-db-tunnel-protocol-from-other_config.XCP-ng.patch