### PR TITLE
Only count tested SRs for leaked VDIs

### DIFF
--- a/SOURCES/xapi-1.249.36-only-count-vdis-tested-sr.backport.patch
+++ b/SOURCES/xapi-1.249.36-only-count-vdis-tested-sr.backport.patch
@@ -1,0 +1,78 @@
+From 0e0ef8180d0a695ec3e2dc5e0b875d8b54f43ebf Mon Sep 17 00:00:00 2001
+From: BenjiReis <benjamin.reis@vates.fr>
+Date: Fri, 6 Oct 2023 12:20:00 +0200
+Subject: [PATCH] Only count VDIs on tested SRs
+
+When using `-sr` or `-default-sr` only
+count VDIs on those SR to check for leak
+VDIs.
+
+Signed-off-by: BenjiReis <benjamin.reis@vates.fr>
+---
+ ocaml/quicktest/qt_filter.ml | 38 ++++++++++++++++++++++++++----------
+ 1 file changed, 28 insertions(+), 10 deletions(-)
+
+diff --git a/ocaml/quicktest/qt_filter.ml b/ocaml/quicktest/qt_filter.ml
+index 7d5a11e9aad..44af7d09652 100644
+--- a/ocaml/quicktest/qt_filter.ml
++++ b/ocaml/quicktest/qt_filter.ml
+@@ -25,31 +25,49 @@ let count_vdis rpc session_id sr =
+   in
+   List.length managed_vdis
+
++let get_test_sr_uuid () =
++  match (!A.use_default_sr, !A.sr) with
++  | true, _ ->
++      let pool = Qt.get_pool !A.rpc !session_id in
++      let sr =
++        Client.Client.Pool.get_default_SR ~rpc:!A.rpc ~session_id:!session_id
++          ~self:pool
++      in
++      Client.Client.SR.get_uuid ~rpc:!A.rpc ~session_id:!session_id ~self:sr
++  | _, uuid when uuid <> "" ->
++      uuid
++  | _, _ ->
++      ""
++
+ (** Called before the quicktests start to save the original state.
+     This data will be used by [finish] to check for any resource leaks. *)
+ let init () =
+   session_id := Qt.init_session !A.rpc !A.username !A.password ;
++  let test_sr_uuid = get_test_sr_uuid () in
+   Client.Client.SR.get_all_records ~rpc:!A.rpc ~session_id:!session_id
+   |> List.iter (fun (ref, sr) ->
+-         if List.mem `scan sr.API.sR_allowed_operations then
+-           let before = count_vdis !A.rpc !session_id ref in
+-           Hashtbl.add vdi_count sr.API.sR_uuid before
++         if test_sr_uuid = "" || sr.API.sR_uuid = test_sr_uuid then
++           if List.mem `scan sr.API.sR_allowed_operations then
++             let before = count_vdis !A.rpc !session_id ref in
++             Hashtbl.add vdi_count sr.API.sR_uuid before
+      )
+
+ (** Called at the end of the quicktests to check that no resources leaked
+     during the test run *)
+ let finish () =
++  let test_sr_uuid = get_test_sr_uuid () in
+   Client.Client.SR.get_all_records ~rpc:!A.rpc ~session_id:!session_id
+   |> List.iter (fun (ref, sr) ->
+          match Hashtbl.find_opt vdi_count sr.API.sR_uuid with
+          | Some before ->
+-             if List.mem `scan sr.API.sR_allowed_operations then
+-               let after = count_vdis !A.rpc !session_id ref in
+-               if after <> before then
+-                 failwith
+-                   (Printf.sprintf "VDIs leaked on SR %s: before=%d, after=%d"
+-                      sr.API.sR_uuid before after
+-                   )
++             if test_sr_uuid = "" || sr.API.sR_uuid = test_sr_uuid then
++               if List.mem `scan sr.API.sR_allowed_operations then
++                 let after = count_vdis !A.rpc !session_id ref in
++                 if after <> before then
++                   failwith
++                     (Printf.sprintf "VDIs leaked on SR %s: before=%d, after=%d"
++                        sr.API.sR_uuid before after
++                     )
+          | None ->
+              ()
+      )

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -5,7 +5,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 1.249.36
-Release: 1.2%{?xsrel}%{?dist}
+Release: 1.3%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -30,6 +30,7 @@ Patch1012: xapi-1.249.32-redirect-fileserver-https.backport.patch
 Patch1013: xapi-1.249.32-quicktest-handle-empty-sr-list.backport.patch
 Patch1014: xapi-1.249.32-use-lib-guess-content-type.backport.patch
 Patch1015: xsa459-xen-api.patch
+Patch1016: xapi-1.249.36-only-count-vdis-tested-sr.backport.patch
 
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
@@ -464,6 +465,9 @@ Coverage files from unit tests
 %endif
 
 %changelog
+* Fri Jul 16 2024 Benjamin Reis <benjamin.reis@vates.tech> - 1.249.36-1.3
+- Add xapi-1.249.36-only-count-vdis-tested-sr.backport.patch
+
 * Mon Jul 15 2024 Benjamin Reis <benjamin.reis@vates.tech> - 1.249.36-1.2
 - Add xsa459-xen-api.patch
 


### PR DESCRIPTION
See: https://github.com/xapi-project/xen-api/pull/5189