### PR TITLE
Do not raise when a certificate doesn't on XAPI startup

### DIFF
--- a/SOURCES/xapi-24.19-2-fix-pem-fingerprint-startup.XCP-ng.patch
+++ b/SOURCES/xapi-24.19-2-fix-pem-fingerprint-startup.XCP-ng.patch
@@ -1,0 +1,40 @@
+Inspired by: https://github.com/xapi-project/xen-api/pull/6006
+
+Do not raise when a certificate doesn't exist after a XAPI upgrade.
+`sdn-controller-ca.pem` could have been lost in a previous upgrade,
+failing reading it would prevent XAPI from starting.
+
+diff --git i/ocaml/xapi/certificates.ml w/ocaml/xapi/certificates.ml
+index 33775182a..671957630 100644
+--- i/ocaml/xapi/certificates.ml
++++ w/ocaml/xapi/certificates.ml
+@@ -278,14 +278,21 @@ end = struct
+       (fun (self, record) ->
+         let read_fingerprints filename =
+           let ( let* ) = Result.bind in
+-          let* certificate =
+-            Xapi_stdext_unix.Unixext.string_of_file filename
+-            |> Cstruct.of_string
+-            |> X509.Certificate.decode_pem
+-          in
+-          let sha1 = pp_fingerprint ~hash_type:`SHA1 certificate in
+-          let sha256 = pp_fingerprint ~hash_type:`SHA256 certificate in
+-          Ok (sha1, sha256)
++          try
++            let* certificate =
++              Xapi_stdext_unix.Unixext.string_of_file filename
++              |> Cstruct.of_string
++              |> X509.Certificate.decode_pem
++            in
++            let sha1 = pp_fingerprint ~hash_type:`SHA1 certificate in
++            let sha256 = pp_fingerprint ~hash_type:`SHA256 certificate in
++            Ok (sha1, sha256)
++          with
++          | Unix.Unix_error (Unix.ENOENT, _, _) ->
++              Error
++                (`Msg (Printf.sprintf "filename %s does not exist" filename))
++          | exn ->
++              Error (`Msg (Printexc.to_string exn))
+         in
+         let filename =
+           Filename.concat

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -18,7 +18,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 24.19.2
-Release: 1.8%{?xsrel}%{?dist}
+Release: 1.9%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -81,6 +81,8 @@ Patch1009: xapi-24.19.2-keep-address-type-network-reset.XCP-ng.patch
 Patch1010: xapi-24.19.2-keep-ipv6-management-disable.XCP-ng.patch
 Patch1011: xapi-24.19.2-ipv6-pool-eject.XCP-ng.patch
 Patch1012: xapi-24.19.2-ipv6-virtual-pif.XCP-ng.patch.patch
+# To remove once https://github.com/xapi-project/xen-api/pull/6006 is released
+Patch1013: xapi-24.19-2-fix-pem-fingerprint-startup.XCP-ng.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1412,6 +1414,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Thu Oct 10 2024 Benjamin Reis <benjamin.reis@vates.tech> - 24.19.2-1.9
+- Add xapi-24.19-2-fix-pem-fingerprint-startup.XCP-ng.patch
+
 * Tue Oct 01 2024 Benjamin Reis <benjamin.reis@vates.tech> - 24.19.2-1.8
 - Add xapi-24.19.2-ipv6-virtual-pif.XCP-ng.patch
 


### PR DESCRIPTION
See: https://github.com/xapi-project/xen-api/pull/6006

`sdn-controller-ca.pem` could have been lost in a previous upgrade, failing reading it would prevent XAPI from starting.