### PR TITLE
Increase wait-init-complete timeout

### DIFF
--- a/SOURCES/xapi-1.249.38-increase-wait-init-complete-timeout.backport.patch
+++ b/SOURCES/xapi-1.249.38-increase-wait-init-complete-timeout.backport.patch
@@ -1,0 +1,38 @@
+From 801dd96cdbcdf0f1fc412859aed46005040b0c57 Mon Sep 17 00:00:00 2001
+From: Thierry Escande <thierry.escande@vates.tech>
+Date: Fri, 8 Nov 2024 16:27:26 +0100
+Subject: [PATCH] Increase wait-init-complete timeout
+Content-Type: text/plain; charset = "utf-8"
+Content-Transfert-Encoding: 8bit
+
+When a host starts, the systemd service xapi-wait-init-complete waiting
+on the creation of the xapi init cookie file may fail on timeout for a
+matter of seconds. This patch adds 1 minute (300 seconds total) to the
+timeout passed to the script xapi-wait-init-complete.
+
+Signed-off-by: Thierry Escande <thierry.escande@vates.tech>
+---
+
+XCP-ng notes:
+Upstream commit 801dd96cd
+Modified to apply on top of xapi-1.249.38
+
+ scripts/xapi-wait-init-complete.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/xapi-wait-init-complete.service b/scripts/xapi-wait-init-complete.service
+index 737daad..bbc7780 100644
+--- a/scripts/xapi-wait-init-complete.service
++++ b/scripts/xapi-wait-init-complete.service
+@@ -6,7 +6,7 @@ Before=xapi-init-complete.target
+ 
+ [Service]
+ Type=oneshot
+-ExecStart=@BINDIR@/xapi-wait-init-complete 240
++ExecStart=@BINDIR@/xapi-wait-init-complete 300
+ RemainAfterExit=yes
+ 
+ [Install]
+-- 
+2.45.2
+

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -7,7 +7,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 1.249.38
-Release: 1.1%{?xsrel}%{?dist}
+Release: 1.2%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -32,6 +32,7 @@ Patch1012: xapi-1.249.32-redirect-fileserver-https.backport.patch
 Patch1013: xapi-1.249.32-quicktest-handle-empty-sr-list.backport.patch
 Patch1014: xapi-1.249.32-use-lib-guess-content-type.backport.patch
 Patch1015: xapi-1.249.36-only-count-vdis-tested-sr.backport.patch
+Patch1016: xapi-1.249.38-increase-wait-init-complete-timeout.backport.patch
 
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
@@ -466,6 +467,9 @@ Coverage files from unit tests
 %endif
 
 %changelog
+* Wed Dec 11 2024 Thierry Escande <thierry.escande@vates.tech> - 1.249.38-1.2
+- Add upstream patch to increase xapi-wait-init-complete service timeout
+
 * Thu Oct 24 2024 Gael Duperrey <gduperrey@vates.tech> - 1.249.38-1.1
 - Sync with hotfix XS82ECU1074
 - Removed xsa459-xen-api as it was integrated upstream.


### PR DESCRIPTION
When a host starts, the systemd service xapi-wait-init-complete waiting on the creation of the xapi init cookie file may fail on timeout for a matter of seconds. This patch adds 1 minute to the timeout passed to the script xapi-wait-init-complete and sets it to 300 seconds.

This service has no impact since no other service actually waits on its completion and this will ease our CI tests if this it stops failing.