### PR TITLE
Backport vncterm fix for PVH guests

### DIFF
--- a/SOURCES/0002-xenopsd-start-vncterm-for-PVH-guests.patch
+++ b/SOURCES/0002-xenopsd-start-vncterm-for-PVH-guests.patch
@@ -1,0 +1,28 @@
+From 6ba654440cfd040ebb1d1f6a60588fc343185827 Mon Sep 17 00:00:00 2001
+Message-ID: <6ba654440cfd040ebb1d1f6a60588fc343185827.1742486427.git.teddy.astie@outlook.fr>
+In-Reply-To: <6e04ead07469426e1c2f84627ceac428fd212ee2.1742486427.git.teddy.astie@outlook.fr>
+References: <6e04ead07469426e1c2f84627ceac428fd212ee2.1742486427.git.teddy.astie@outlook.fr>
+From: Pau Ruiz Safont <pau.ruizsafont@cloud.com>
+Date: Mon, 17 Mar 2025 11:48:08 +0000
+Subject: [PATCH 2/3] xenopsd: start vncterm for PVH guests
+
+Signed-off-by: Pau Ruiz Safont <pau.ruizsafont@cloud.com>
+---
+ ocaml/xenopsd/xc/xenops_server_xen.ml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ocaml/xenopsd/xc/xenops_server_xen.ml b/ocaml/xenopsd/xc/xenops_server_xen.ml
+index ba3dd7e2b..397b47857 100644
+--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
++++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
+@@ -2314,6 +2314,7 @@ module VM = struct
+         (create_device_model_config vm vmextra vbds vifs vgpus vusbs) ;
+       match vm.Vm.ty with
+       | Vm.PV {vncterm= true; vncterm_ip= ip; _}
++      | Vm.PVH {vncterm= true; vncterm_ip= ip; _}
+       | Vm.PVinPVH {vncterm= true; vncterm_ip= ip; _} ->
+           Service.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
+       | _ ->
+-- 
+2.47.2
+

--- a/SOURCES/0003-xenopsd-make-vncterm-less-errorprone.patch
+++ b/SOURCES/0003-xenopsd-make-vncterm-less-errorprone.patch
@@ -1,0 +1,41 @@
+From 24e892760447c81afc37c46d622211cbed4aafd4 Mon Sep 17 00:00:00 2001
+Message-ID: <24e892760447c81afc37c46d622211cbed4aafd4.1742486427.git.teddy.astie@outlook.fr>
+In-Reply-To: <6e04ead07469426e1c2f84627ceac428fd212ee2.1742486427.git.teddy.astie@outlook.fr>
+References: <6e04ead07469426e1c2f84627ceac428fd212ee2.1742486427.git.teddy.astie@outlook.fr>
+From: Pau Ruiz Safont <pau.ruizsafont@cloud.com>
+Date: Mon, 17 Mar 2025 13:36:15 +0000
+Subject: [PATCH 3/3] xenopsd: make vncterm less errorprone
+
+Previous match had a wildcard which made it easy to miss added cases, change it
+so all the guest types have to be enumerated.
+
+Signed-off-by: Pau Ruiz Safont <pau.ruizsafont@cloud.com>
+---
+ ocaml/xenopsd/xc/xenops_server_xen.ml | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/ocaml/xenopsd/xc/xenops_server_xen.ml b/ocaml/xenopsd/xc/xenops_server_xen.ml
+index 397b47857..db54f1829 100644
+--- a/ocaml/xenopsd/xc/xenops_server_xen.ml
++++ b/ocaml/xenopsd/xc/xenops_server_xen.ml
+@@ -2313,11 +2313,12 @@ module VM = struct
+         )
+         (create_device_model_config vm vmextra vbds vifs vgpus vusbs) ;
+       match vm.Vm.ty with
+-      | Vm.PV {vncterm= true; vncterm_ip= ip; _}
+-      | Vm.PVH {vncterm= true; vncterm_ip= ip; _}
+-      | Vm.PVinPVH {vncterm= true; vncterm_ip= ip; _} ->
+-          Service.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
+-      | _ ->
++      | PV {vncterm; vncterm_ip= ip; _}
++      | PVH {vncterm; vncterm_ip= ip; _}
++      | PVinPVH {vncterm; vncterm_ip= ip; _} ->
++          if vncterm then
++            Service.PV_Vnc.start ~xs ?ip di.Xenctrl.domid
++      | HVM _ ->
+           ()
+     with Device.Ioemu_failed (name, msg) ->
+       raise (Xenopsd_error (Failed_to_start_emulator (vm.Vm.id, name, msg)))
+-- 
+2.47.2
+

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -82,7 +82,9 @@ Patch1009: xen-api-24.39.1-debug-traces-for-is_component_enabled.patch
 Patch1010: xen-api-24.39.1-0001-CA-399669-Do-not-exit-with-error-when-IPMI-readings-.patch
 Patch1011: xen-api-24.39.1-0002-rrdp-dcmi-remove-extraneous-I-argument-from-cli-call.patch
 Patch1012: xen-api-24.39.1-0003-CA-399669-Detect-a-reason-for-IPMI-readings-being-un.patch
-
+# Backport fixes for vncterm for PVH
+Patch1013: 0002-xenopsd-start-vncterm-for-PVH-guests.patch
+Patch1014: 0003-xenopsd-make-vncterm-less-errorprone.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1368,6 +1370,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Thu Mar 20 2025 Teddy Astie <teddy.astie@vates.tech> - 24.39.1-2
+- Backport vncterm fix for PVH guests
+
 * Fri Feb 14 2025 Yann Dirson <yann.dirson@vates.tech> - 24.39.1-1.1
 - Update to upstream 24.39.1-1
 - Reformat changelog to allow diffing with upstream


### PR DESCRIPTION
Currently, all PVH guests lack the VNC console (making them unusable from XAPI client like Xen Orchestra).
XAPI v25.14.0 provides a trivial fix (https://github.com/xapi-project/xen-api/pull/6363) which we can backport for XCP-ng 8.3.