### PR TITLE
Mitigate issue with SR.scan

### DIFF
--- a/SOURCES/0001-CA-399757-Add-CAS-style-check-for-SR-scan.patch
+++ b/SOURCES/0001-CA-399757-Add-CAS-style-check-for-SR-scan.patch
@@ -1,0 +1,95 @@
+From 7cad41ca27314b76c9a3edf1da3d1600b5670361 Mon Sep 17 00:00:00 2001
+From: Vincent Liu <shuntian.liu2@cloud.com>
+Date: Tue, 1 Oct 2024 17:18:49 +0100
+Subject: [PATCH] CA-399757: Add CAS style check for SR scan
+
+SR.scan is currently not an atomic operation, and this has caused
+problems as during the scan itself, there might be other calls changing
+the state of the database, such as VDI.db_introduce called by SM, if
+using SMAPIv1. This will confuse SR.scan as it sees an outdated
+snapshot.
+
+The proposed workaround would be add a CAS style check for SR.scan,
+which will refuse to update the db if it detects changes. This is still
+subject to the TOCTOU problem, but should reduce the racing window.
+
+Signed-off-by: Vincent Liu <shuntian.liu2@cloud.com>
+---
+ ocaml/xapi/xapi_sr.ml | 63 ++++++++++++++++++++++++++++++-------------
+ 1 file changed, 44 insertions(+), 19 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_sr.ml b/ocaml/xapi/xapi_sr.ml
+index 7a83493b2..8af5bd6e6 100644
+--- a/ocaml/xapi/xapi_sr.ml
++++ b/ocaml/xapi/xapi_sr.ml
+@@ -786,26 +786,51 @@ let scan ~__context ~sr =
+   SRScanThrottle.execute (fun () ->
+       transform_storage_exn (fun () ->
+           let sr_uuid = Db.SR.get_uuid ~__context ~self:sr in
+-          let vs, sr_info =
+-            C.SR.scan2 (Ref.string_of task)
+-              (Storage_interface.Sr.of_string sr_uuid)
+-          in
+-          let db_vdis =
+-            Db.VDI.get_records_where ~__context
+-              ~expr:(Eq (Field "SR", Literal sr'))
+-          in
+-          update_vdis ~__context ~sr db_vdis vs ;
+-          let virtual_allocation =
+-            List.fold_left Int64.add 0L
+-              (List.map (fun v -> v.Storage_interface.virtual_size) vs)
++          (* CA-399757: Do not update_vdis unless we are sure that the db was not
++             changed during the scan. If it was, retry the scan operation. This
++             change might be a result of the SMAPIv1 call back into xapi with
++             the db_introduce call, for example.
++
++             Note this still suffers TOCTOU problem, but a complete operation is not easily
++             implementable without rearchitecting the storage apis *)
++          let rec scan_rec limit =
++            let find_vdis () =
++              Db.VDI.get_records_where ~__context
++                ~expr:(Eq (Field "SR", Literal sr'))
++            in
++            let db_vdis_before = find_vdis () in
++            let vs, sr_info =
++              C.SR.scan2 (Ref.string_of task)
++                (Storage_interface.Sr.of_string sr_uuid)
++            in
++            let db_vdis_after = find_vdis () in
++            if limit > 0 && db_vdis_after <> db_vdis_before then
++              (scan_rec [@tailcall]) (limit - 1)
++            else if limit = 0 then
++              raise
++                (Api_errors.Server_error
++                   (Api_errors.internal_error, ["SR.scan retry limit exceeded"])
++                )
++            else (
++              update_vdis ~__context ~sr db_vdis_after vs ;
++              let virtual_allocation =
++                List.fold_left
++                  (fun acc v -> Int64.add v.Storage_interface.virtual_size acc)
++                  0L vs
++              in
++              Db.SR.set_virtual_allocation ~__context ~self:sr
++                ~value:virtual_allocation ;
++              Db.SR.set_physical_size ~__context ~self:sr
++                ~value:sr_info.total_space ;
++              Db.SR.set_physical_utilisation ~__context ~self:sr
++                ~value:(Int64.sub sr_info.total_space sr_info.free_space) ;
++              Db.SR.remove_from_other_config ~__context ~self:sr ~key:"dirty" ;
++              Db.SR.set_clustered ~__context ~self:sr ~value:sr_info.clustered
++            )
+           in
+-          Db.SR.set_virtual_allocation ~__context ~self:sr
+-            ~value:virtual_allocation ;
+-          Db.SR.set_physical_size ~__context ~self:sr ~value:sr_info.total_space ;
+-          Db.SR.set_physical_utilisation ~__context ~self:sr
+-            ~value:(Int64.sub sr_info.total_space sr_info.free_space) ;
+-          Db.SR.remove_from_other_config ~__context ~self:sr ~key:"dirty" ;
+-          Db.SR.set_clustered ~__context ~self:sr ~value:sr_info.clustered
++          (* XXX Retry 10 times, and then give up. We should really expect to
++             reach this retry limit though, unless something really bad has happened.*)
++          scan_rec 10
+       )
+   )
+ 

--- a/SOURCES/0002-Improve-the-scan-comparison-logic.patch
+++ b/SOURCES/0002-Improve-the-scan-comparison-logic.patch
@@ -1,0 +1,61 @@
+From 2eb31af08d6ccbfb2be53d990df40264d8e53ede Mon Sep 17 00:00:00 2001
+From: Vincent Liu <shuntian.liu2@cloud.com>
+Date: Tue, 10 Dec 2024 14:19:00 +0000
+Subject: [PATCH] Improve the scan comparison logic
+
+For the scan retry, previously we were comparing the entire vdi data
+structure from the database using the (<>) operator. This is a bit
+wasteful and not very stable. Instead let us just compare the vdi refs,
+since the race here comes from `VDI.db_{introduce,forget}`, which would
+only add/remove vdis from the db, but not change its actual data
+structure.
+
+Also add a bit more logging when retrying, since this should not happen
+very often.
+
+Signed-off-by: Vincent Liu <shuntian.liu2@cloud.com>
+---
+ ocaml/xapi/xapi_sr.ml | 23 +++++++++++++++++++++--
+ 1 file changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_sr.ml b/ocaml/xapi/xapi_sr.ml
+index 8af5bd6e6..a504f54c0 100644
+--- a/ocaml/xapi/xapi_sr.ml
++++ b/ocaml/xapi/xapi_sr.ml
+@@ -798,15 +798,34 @@ let scan ~__context ~sr =
+               Db.VDI.get_records_where ~__context
+                 ~expr:(Eq (Field "SR", Literal sr'))
+             in
++            (* It is sufficient to just compare the refs in two db_vdis, as this
++               is what update_vdis uses to determine what to delete *)
++            let vdis_ref_equal db_vdi1 db_vdi2 =
++              Listext.List.set_difference (List.map fst db_vdi1)
++                (List.map fst db_vdi2)
++              = []
++            in
+             let db_vdis_before = find_vdis () in
+             let vs, sr_info =
+               C.SR.scan2 (Ref.string_of task)
+                 (Storage_interface.Sr.of_string sr_uuid)
+             in
+             let db_vdis_after = find_vdis () in
+-            if limit > 0 && db_vdis_after <> db_vdis_before then
++            if limit > 0 && not (vdis_ref_equal db_vdis_before db_vdis_after)
++            then (
++              debug
++                "%s detected db change while scanning, before scan vdis %s, \
++                 after scan vdis %s, retry limit left %d"
++                __FUNCTION__
++                (List.map (fun (_, v) -> v.vDI_uuid) db_vdis_before
++                |> String.concat ","
++                )
++                (List.map (fun (_, v) -> v.vDI_uuid) db_vdis_after
++                |> String.concat ","
++                )
++                limit ;
+               (scan_rec [@tailcall]) (limit - 1)
+-            else if limit = 0 then
++            ) else if limit = 0 then
+               raise
+                 (Api_errors.Server_error
+                    (Api_errors.internal_error, ["SR.scan retry limit exceeded"])

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -23,7 +23,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 24.39.1
-Release: 1.1%{?xsrel}%{?dist}
+Release: 1.2.0.gtn.2%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -82,6 +82,10 @@ Patch1009: xen-api-24.39.1-debug-traces-for-is_component_enabled.patch
 Patch1010: xen-api-24.39.1-0001-CA-399669-Do-not-exit-with-error-when-IPMI-readings-.patch
 Patch1011: xen-api-24.39.1-0002-rrdp-dcmi-remove-extraneous-I-argument-from-cli-call.patch
 Patch1012: xen-api-24.39.1-0003-CA-399669-Detect-a-reason-for-IPMI-readings-being-un.patch
+# Cherry-pick from master (in 24.40.0)
+# Mitigates issue around SR.scan not beeing atomic
+Patch1013: 0001-CA-399757-Add-CAS-style-check-for-SR-scan.patch
+Patch1014: 0002-Improve-the-scan-comparison-logic.patch
 
 
 %{?_cov_buildrequires}
@@ -1368,6 +1372,13 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Wed Apr 3 2025 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 24.39.1-1.3
+- Add CAS style check for SR scan
+- Improve the scan comparison logic
+
+* Tue Apr 2 2025 Guillaume Thouvenin <guillaume.thouvenin@vates.tech> - 24.39.1-1.2
+- (this version is not used)
+
 * Fri Feb 14 2025 Yann Dirson <yann.dirson@vates.tech> - 24.39.1-1.1
 - Update to upstream 24.39.1-1
 - Reformat changelog to allow diffing with upstream


### PR DESCRIPTION
This patches cherry-picked two commits from 24.40.0 that proposed a workaround for SR.scan issues because operation is not atomic.