### PR TITLE
8.2: Backport a xapi_guest_agent fix

### DIFF
--- a/SOURCES/xapi-1.249.41-guest_agent-Update-xenstore-keys-for-Windows-PV.patch
+++ b/SOURCES/xapi-1.249.41-guest_agent-Update-xenstore-keys-for-Windows-PV.patch
@@ -1,0 +1,99 @@
+From d7261f4aec2e42339473cf44c5c59a8529d2f169 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Tue, 15 Apr 2025 14:19:27 +0100
+Subject: [PATCH] xapi_guest_agent: Update xenstore keys for Windows PV drivers
+ versions
+
+Windows PV drivers do not store their version information into
+"drivers/{xeneventchn,xenvbd,xennet}" xenstore keys since 2015, see:
+
+* PV drivers commit 784af16810d705ba2bc02bab6ac93b24119f886c
+  (Publish distribution information to xenstore)
+  https://xenbits.xen.org/gitweb/\?p\=pvdrivers/win/xenbus.git\;a\=commit\;h\=784af16810d705ba2bc02bab6ac93b24119f886c
+
+* Xen commit 71e64e163b2dae7d08f7d77ee942749663f484d5
+  (docs: Introduce xenstore paths for PV driver information)
+  https://xenbits.xen.org/gitweb/\?p\=xen.git\;a\=commit\;h\=71e64e163b2dae7d08f7d77ee942749663f484d5
+
+Instead it is stored like this:
+drivers/0 = "XenServer XENBUS 9.1.9.105 "
+drivers/1 = "XenServer XENVBD 9.1.8.79 "
+drivers/2 = "XenServer XENVIF 9.1.12.101 "
+drivers/3 = "XenServer XENIFACE 9.1.10.87 "
+drivers/4 = "XenServer XENNET 9.1.7.65 "
+
+Modify xapi_guest_agent to list such entries under "drivers/" and present
+version information for each driver.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/xapi/xapi_guest_agent.ml | 46 ++++++++++++++++++++++++++++------
+ 1 file changed, 39 insertions(+), 7 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_guest_agent.ml b/ocaml/xapi/xapi_guest_agent.ml
+index b8262a4c2..d436b0513 100644
+--- a/ocaml/xapi/xapi_guest_agent.ml
++++ b/ocaml/xapi/xapi_guest_agent.ml
+@@ -32,12 +32,6 @@ end)
+    NB each key is annotated with whether it appears in windows and/or linux *)
+ let pv_drivers_version =
+   [
+-    ("drivers/xenevtchn", "xenevtchn")
+-  ; (* windows *)
+-    ("drivers/xenvbd", "xenvbd")
+-  ; (* windows *)
+-    ("drivers/xennet", "xennet")
+-  ; (* windows *)
+     ("attr/PVAddons/MajorVersion", "major")
+   ; (* linux + windows *)
+     ("attr/PVAddons/MinorVersion", "minor")
+@@ -272,7 +266,45 @@ let get_initial_guest_metrics (lookup : string -> string option)
+     | None ->
+         []
+   in
+-  let pv_drivers_version = to_map pv_drivers_version
++  (* enumerate all driver versions from xenstore, which are stored like
++     drivers/0 = "XenServer XENBUS 9.1.9.105 "
++     drivers/1 = "XenServer XENVBD 9.1.8.79 "
++     drivers/2 = "XenServer XENVIF 9.1.12.101 "
++     drivers/3 = "XenServer XENIFACE 9.1.10.87 "
++     drivers/4 = "XenServer XENNET 9.1.7.65 "
++
++     (see the format specified in xenstore-paths)
++  *)
++  let get_windows_driver_versions () =
++    (* Only look into directories that are numbers (indices) *)
++    let filter_dirs subdirs =
++      List.filter_map
++        (fun x ->
++          match int_of_string_opt x with
++          | Some _ ->
++              Some ("drivers/" ^ x, x)
++          | None ->
++              None
++        )
++        subdirs
++    in
++    let versions = list "drivers" |> filter_dirs |> to_map in
++    List.filter_map
++      (fun (_, version_string) ->
++        try
++          Scanf.sscanf version_string "%s@ %s@ %s@ %s@\n"
++            (fun vendor driver_name version attr ->
++              Some
++                ( String.lowercase_ascii driver_name
++                , String.concat " " [vendor; version; attr]
++                )
++          )
++        with _ -> None
++      )
++      versions
++  in
++  let pv_drivers_version =
++    to_map pv_drivers_version @ get_windows_driver_versions ()
+   and os_version = to_map os_version
+   and device_id = to_map device_id
+   and networks =
+-- 
+2.49.0
+

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -7,7 +7,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 1.249.41
-Release: %{?xsrel}.1%{?dist}
+Release: %{?xsrel}.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -33,6 +33,8 @@ Patch1013: xapi-1.249.32-quicktest-handle-empty-sr-list.backport.patch
 Patch1014: xapi-1.249.32-use-lib-guess-content-type.backport.patch
 Patch1015: xapi-1.249.36-only-count-vdis-tested-sr.backport.patch
 Patch1016: xapi-1.249.38-increase-wait-init-complete-timeout.backport.patch
+
+Patch1017: xapi-1.249.41-guest_agent-Update-xenstore-keys-for-Windows-PV.patch
 
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
@@ -467,6 +469,9 @@ Coverage files from unit tests
 %endif
 
 %changelog
+* Thu Apr 17 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 1.249.41-1.2
+- Update xenstore keys that Xapi Guest Agent checks for Windows PV driver versions
+
 * Wed Feb 19 2025 Gael Duperrey <gduperrey@vates.tech> - 1.249.41-1.1
 - Sync with hotfix XS82ECU1084
 - *** Upstream changelog ***


### PR DESCRIPTION
This 10-year old misalignment between xapi and Windows PV drivers explains the missing driver versions in VM's parameters we've been seeing.