### PR TITLE
8.3: Fix xapi/xenopsd race during suspend

### DIFF
--- a/SOURCES/0013-xapi_xenops-Try-to-avoid-a-race-during-suspend.patch
+++ b/SOURCES/0013-xapi_xenops-Try-to-avoid-a-race-during-suspend.patch
@@ -1,0 +1,120 @@
+From df4c2fff9c8c9633bf56b6c5481bfc973c1f9005 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Tue, 6 May 2025 14:20:41 +0100
+Subject: [PATCH] xapi_xenops: Try to avoid a race during suspend
+
+As described in [#6451](https://github.com/xapi-project/xen-api/issues/6451),
+a xapi event could prevent update_vm from pulling the latest Xenopsd metadata,
+overwriting it with stale information. In case of suspend, this would make the
+snapshot unresumable, raising an assert in xenopsd due to incongruities in
+memory values.
+
+Grab the metadata mutex for the duration of the entire power state update
+function, which, in my testing, prevents the race and fixes the broken suspend.
+
+Accordingly update Xenopsd_metadata.pull to handle recursive mutex locking
+gracefully.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/xapi/xapi_xenops.ml | 73 ++++++++++++++++++++++++---------------
+ 1 file changed, 45 insertions(+), 28 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_xenops.ml b/ocaml/xapi/xapi_xenops.ml
+index 1d17bc5b7..0c49fbc6e 100644
+--- a/ocaml/xapi/xapi_xenops.ml
++++ b/ocaml/xapi/xapi_xenops.ml
+@@ -1692,7 +1692,10 @@ module Xenopsd_metadata = struct
+ 
+   (* Unregisters a VM with xenopsd, and cleans up metadata and caches *)
+   let pull ~__context id =
+-    with_lock metadata_m (fun () ->
++    (* Detect if mutex is already locked one level above *)
++    (try Mutex.lock metadata_m with Sys_error _ -> ()) ;
++    finally
++      (fun () ->
+         info "xenops: VM.export_metadata %s" id ;
+         let dbg = Context.string_of_task_and_tracing __context in
+         let module Client =
+@@ -1719,7 +1722,8 @@ module Xenopsd_metadata = struct
+         in
+         delete_nolock ~__context id ;
+         md
+-    )
++      )
++      (fun () -> try Mutex.unlock metadata_m with Sys_error _ -> ())
+ 
+   let delete ~__context id =
+     with_lock metadata_m (fun () -> delete_nolock ~__context id)
+@@ -2038,32 +2042,45 @@ let update_vm ~__context id =
+                   "Will update VM.allowed_operations because power_state has \
+                    changed." ;
+                 should_update_allowed_operations := true ;
+-                debug "xenopsd event: Updating VM %s power_state <- %s" id
+-                  (Record_util.vm_power_state_to_string power_state) ;
+-                (* This will mark VBDs, VIFs as detached and clear resident_on
+-                   if the VM has permanently shutdown.  current-operations
+-                   should not be reset as there maybe a checkpoint is ongoing*)
+-                Xapi_vm_lifecycle.force_state_reset_keep_current_operations
+-                  ~__context ~self ~value:power_state ;
+-                if power_state = `Running then create_guest_metrics_if_needed () ;
+-                if power_state = `Suspended || power_state = `Halted then (
+-                  Xapi_network.detach_for_vm ~__context ~host:localhost ~vm:self ;
+-                  Storage_access.reset ~__context ~vm:self
+-                ) ;
+-                if power_state = `Halted then
+-                  Xenopsd_metadata.delete ~__context id ;
+-                ( if power_state = `Suspended then
+-                    let md = Xenopsd_metadata.pull ~__context id in
+-                    match md.Metadata.domains with
+-                    | None ->
+-                        error "Suspended VM has no domain-specific metadata"
+-                    | Some x ->
+-                        Db.VM.set_last_booted_record ~__context ~self ~value:x ;
+-                        debug "VM %s last_booted_record set to %s"
+-                          (Ref.string_of self) x
+-                ) ;
+-                if power_state = `Halted then
+-                  !trigger_xenapi_reregister ()
++
++                let update_allowed_operations () =
++                  debug "xenopsd event: Updating VM %s power_state <- %s" id
++                    (Record_util.vm_power_state_to_string power_state) ;
++                  (* This will mark VBDs, VIFs as detached and clear resident_on
++                     if the VM has permanently shutdown.  current-operations
++                     should not be reset as there maybe a checkpoint is ongoing*)
++                  Xapi_vm_lifecycle.force_state_reset_keep_current_operations
++                    ~__context ~self ~value:power_state ;
++                  if power_state = `Running then
++                    create_guest_metrics_if_needed () ;
++                  if power_state = `Suspended || power_state = `Halted then (
++                    Xapi_network.detach_for_vm ~__context ~host:localhost
++                      ~vm:self ;
++                    Storage_access.reset ~__context ~vm:self
++                  ) ;
++                  if power_state = `Halted then
++                    Xenopsd_metadata.delete ~__context id ;
++                  ( if power_state = `Suspended then
++                      let md = Xenopsd_metadata.pull ~__context id in
++                      match md.Metadata.domains with
++                      | None ->
++                          error "Suspended VM has no domain-specific metadata"
++                      | Some x ->
++                          Db.VM.set_last_booted_record ~__context ~self ~value:x ;
++                          debug "VM %s last_booted_record set to %s"
++                            (Ref.string_of self) x
++                  ) ;
++                  if power_state = `Halted then
++                    !trigger_xenapi_reregister ()
++                in
++
++                (* Lock metadata_m mutex for the entire update function to
++                   prevent a race where Xenopsd_metadata.push inbetween would
++                   overwrite the data we expect to pull and break the snapshot *)
++                if power_state = `Suspended then (
++                  with_lock metadata_m update_allowed_operations
++                ) else
++                  update_allowed_operations ()
+               with e ->
+                 error "Caught %s: while updating VM %s power_state"
+                   (Printexc.to_string e) id

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 25.6.0
-Release: 1.3%{?xsrel}%{?dist}
+Release: 1.4%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -97,6 +97,9 @@ Patch1011: 0011-Check-that-there-are-no-changes-during-SR.scan.patch
 
 # Merged upstream, will be in v25.17.0
 Patch1012: 0012-xapi_guest_agent-Update-xenstore-keys-for-Windows-PV.patch
+
+# Posted upstream: https://github.com/xapi-project/xen-api/pull/6454
+Patch1013: 0013-xapi_xenops-Try-to-avoid-a-race-during-suspend.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1412,6 +1415,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Wed May 07 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 25.6.0-1.4
+- Fix a race during VM suspend that would make the snapshot unresumable
+
 * Wed Apr 23 2025 Gaëtan Lehmann <gaetan.lehmann@vates.tech> - 25.6.0-1.3
 - Remove remaining dependency on rrd-client-lib in xcp-rrdd-devel.
 


### PR DESCRIPTION
I've manually tested this fix and could not reproduce the issue with the xenopsd assert making a snapshot unresumable anymore.

I will post this upstream shortly - so think of this as a temporary hack that might change.
UPD: mostly cosmetic issues requested upstream, so should be all good