### PR TITLE
8.3: Backport a fix for a xenopsd deadlock

### DIFF
--- a/SOURCES/0010-CA-408841-rrd-don-t-update-rrds-when-ds_update-is-ca.patch
+++ b/SOURCES/0010-CA-408841-rrd-don-t-update-rrds-when-ds_update-is-ca.patch
@@ -1,4 +1,4 @@
-From 78dfefeb3f85a1a97ad62d76d262deb810e006ac Mon Sep 17 00:00:00 2001
+From 5881065769945c980a3ad6d625401296bf0973fa Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andrii.sultanov@cloud.com>
 Date: Mon, 31 Mar 2025 07:40:58 +0100
 Subject: [PATCH] CA-408841 rrd: don't update rrds when ds_update is called

--- a/SOURCES/0011-Check-that-there-are-no-changes-during-SR.scan.patch
+++ b/SOURCES/0011-Check-that-there-are-no-changes-during-SR.scan.patch
@@ -1,4 +1,4 @@
-From ef924afbd296a39959991a0099393a2f1ef0f681 Mon Sep 17 00:00:00 2001
+From aa2aa6e77eb9748eef0b15685e3f1efb2339a472 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Tue, 8 Apr 2025 18:22:21 +0200
 Subject: [PATCH] Check that there are no changes during SR.scan

--- a/SOURCES/0013-xapi_xenops-Try-to-avoid-a-race-during-suspend.patch
+++ b/SOURCES/0013-xapi_xenops-Try-to-avoid-a-race-during-suspend.patch
@@ -1,4 +1,4 @@
-From df4c2fff9c8c9633bf56b6c5481bfc973c1f9005 Mon Sep 17 00:00:00 2001
+From 4064696677f1b5237e02ef42f8882dda22fa50ea Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Tue, 6 May 2025 14:20:41 +0100
 Subject: [PATCH] xapi_xenops: Try to avoid a race during suspend

--- a/SOURCES/0014-CA-409510-Make-xenopsd-nested-Parallel-atoms-explici.patch
+++ b/SOURCES/0014-CA-409510-Make-xenopsd-nested-Parallel-atoms-explici.patch
@@ -1,0 +1,370 @@
+From f7ef2cf5267bb84ec9ef91bd599ccfb0ce2e6b0b Mon Sep 17 00:00:00 2001
+From: Steven Woods <steven.woods@cloud.com>
+Date: Tue, 29 Apr 2025 11:33:42 +0100
+Subject: [PATCH] CA-409510: Make xenopsd nested Parallel atoms explicit
+
+Each Parallel atom takes up a worker thread whilst its children do the
+actual work, so we have parallel_queues to prevent a deadlock. However,
+nested Parallel atoms take up an additional worker, meaning they can
+still cause a deadlock. This commit adds a new Nested_parallel atomic
+with matching nested_parallel_queues to remove the possibility of this
+deadlock.
+This increases the total number of workers, but these workers are just
+to hold the Nested_parallel Atomics and will not be doing any actual work
+
+Signed-off-by: Steven Woods <steven.woods@cloud.com>
+---
+ ocaml/xenopsd/lib/xenops_server.ml | 196 ++++++++++++++++++-----------
+ quality-gate.sh                    |   2 +-
+ 2 files changed, 126 insertions(+), 72 deletions(-)
+
+diff --git a/ocaml/xenopsd/lib/xenops_server.ml b/ocaml/xenopsd/lib/xenops_server.ml
+index e3f0a77f5..65f9b4fc4 100644
+--- a/ocaml/xenopsd/lib/xenops_server.ml
++++ b/ocaml/xenopsd/lib/xenops_server.ml
+@@ -162,6 +162,8 @@ type atomic =
+   | VM_rename of (Vm.id * Vm.id * rename_when)
+   | VM_import_metadata of (Vm.id * Metadata.t)
+   | Parallel of Vm.id * string * atomic list
++  | Nested_parallel of Vm.id * string * atomic list
++      (** used to make nested parallel atoms explicit, as each atom requires its own worker *)
+   | Serial of Vm.id * string * atomic list
+   | Best_effort of atomic
+ [@@deriving rpcty]
+@@ -272,6 +274,9 @@ let rec name_of_atomic = function
+   | Parallel (_, _, atomics) ->
+       Printf.sprintf "Parallel (%s)"
+         (String.concat " | " (List.map name_of_atomic atomics))
++  | Nested_parallel (_, _, atomics) ->
++      Printf.sprintf "Nested_parallel (%s)"
++        (String.concat " | " (List.map name_of_atomic atomics))
+   | Serial (_, _, atomics) ->
+       Printf.sprintf "Serial (%s)"
+         (String.concat " & " (List.map name_of_atomic atomics))
+@@ -281,7 +286,7 @@ let rec name_of_atomic = function
+ let rec atomic_expires_after = function
+   | Serial (_, _, ops) ->
+       List.map atomic_expires_after ops |> List.fold_left ( +. ) 0.
+-  | Parallel (_, _, ops) ->
++  | Parallel (_, _, ops) | Nested_parallel (_, _, ops) ->
+       List.map atomic_expires_after ops |> List.fold_left Float.max 0.
+   | _ ->
+       (* 20 minutes, in seconds *)
+@@ -901,6 +906,27 @@ module Redirector = struct
+      Parallel atoms, creating a deadlock. *)
+   let parallel_queues = {queues= Queues.create (); mutex= Mutex.create ()}
+ 
++  (* We create another queue only for Nested_parallel atoms for the same reason
++     as parallel_queues. When a Nested_parallel atom is inside a Parallel atom,
++     they are both using a worker whilst not doing any work, so they each need
++     additional space to prevent a deadlock. *)
++  let nested_parallel_queues =
++    {queues= Queues.create (); mutex= Mutex.create ()}
++
++  (* we do not want to use = when comparing queues: queues can contain
++     (uncomparable) functions, and we are only interested in comparing the
++     equality of their static references *)
++  let is_same_redirector q1 q2 = q1 == q2
++
++  let to_string r =
++    match r with
++    | w when is_same_redirector w parallel_queues ->
++        "Parallel"
++    | w when is_same_redirector w nested_parallel_queues ->
++        "Nested_parallel"
++    | _ ->
++        "Default"
++
+   (* When a thread is actively processing a queue, items are redirected to a
+      thread-private queue *)
+   let overrides = ref StringMap.empty
+@@ -1020,6 +1046,7 @@ module Redirector = struct
+           List.concat_map one
+             (default.queues
+             :: parallel_queues.queues
++            :: nested_parallel_queues.queues
+             :: List.map snd (StringMap.bindings !overrides)
+             )
+       )
+@@ -1204,11 +1231,11 @@ module WorkerPool = struct
+      operate *)
+   let count_active queues =
+     with_lock m (fun () ->
+-        (* we do not want to use = when comparing queues: queues can contain
+-           (uncomparable) functions, and we are only interested in comparing the
+-           equality of their static references *)
+         List.map
+-          (fun w -> w.Worker.redirector == queues && Worker.is_active w)
++          (fun w ->
++            Redirector.is_same_redirector w.Worker.redirector queues
++            && Worker.is_active w
++          )
+           !pool
+         |> List.filter (fun x -> x)
+         |> List.length
+@@ -1216,17 +1243,18 @@ module WorkerPool = struct
+ 
+   let find_one queues f =
+     List.fold_left
+-      (fun acc x -> acc || (x.Worker.redirector == queues && f x))
++      (fun acc x ->
++        acc || (Redirector.is_same_redirector x.Worker.redirector queues && f x)
++      )
+       false
+ 
+   (* Clean up any shutdown threads and remove them from the master list *)
+   let gc queues pool =
+     List.fold_left
+       (fun acc w ->
+-        (* we do not want to use = when comparing queues: queues can contain
+-           (uncomparable) functions, and we are only interested in comparing the
+-           equality of their static references *)
+-        if w.Worker.redirector == queues && Worker.get_state w = Worker.Shutdown
++        if
++          Redirector.is_same_redirector w.Worker.redirector queues
++          && Worker.get_state w = Worker.Shutdown
+         then (
+           Worker.join w ; acc
+         ) else
+@@ -1253,7 +1281,8 @@ module WorkerPool = struct
+   let start size =
+     for _i = 1 to size do
+       incr Redirector.default ;
+-      incr Redirector.parallel_queues
++      incr Redirector.parallel_queues ;
++      incr Redirector.nested_parallel_queues
+     done
+ 
+   let set_size size =
+@@ -1268,7 +1297,8 @@ module WorkerPool = struct
+       done
+     in
+     inner Redirector.default ;
+-    inner Redirector.parallel_queues
++    inner Redirector.parallel_queues ;
++    inner Redirector.nested_parallel_queues
+ end
+ 
+ (* Keep track of which VMs we're rebooting so we avoid transient glitches where
+@@ -1569,6 +1599,11 @@ let collect_into apply = function [] -> [] | [op] -> [op] | lst -> apply lst
+ let parallel name ~id =
+   collect_into (fun ls -> [Parallel (id, Printf.sprintf "%s VM=%s" name id, ls)])
+ 
++let nested_parallel name ~id =
++  collect_into (fun ls ->
++      [Nested_parallel (id, Printf.sprintf "%s VM=%s" name id, ls)]
++  )
++
+ let serial name ~id =
+   collect_into (fun ls -> [Serial (id, Printf.sprintf "%s VM=%s" name id, ls)])
+ 
+@@ -1578,6 +1613,9 @@ let serial_concat name ~id lst = serial name ~id (List.concat lst)
+ 
+ let parallel_map name ~id lst f = parallel name ~id (List.concat_map f lst)
+ 
++let nested_parallel_map name ~id lst f =
++  nested_parallel name ~id (List.concat_map f lst)
++
+ let map_or_empty f x = Option.value ~default:[] (Option.map f x)
+ 
+ let rec atomics_of_operation = function
+@@ -1595,7 +1633,7 @@ let rec atomics_of_operation = function
+         let pf = Printf.sprintf in
+         let name_multi = pf "VBDs.activate_epoch_and_plug %s" typ in
+         let name_one = pf "VBD.activate_epoch_and_plug %s" typ in
+-        parallel_map name_multi ~id vbds (fun vbd ->
++        nested_parallel_map name_multi ~id vbds (fun vbd ->
+             serial_concat name_one ~id
+               [
+                 [VBD_set_active (vbd.Vbd.id, true)]
+@@ -1629,11 +1667,11 @@ let rec atomics_of_operation = function
+               vifs
+           ; serial_concat "VGPUs.activate & PCI.plug (SRIOV)" ~id
+               [
+-                parallel_map "VGPUs.activate" ~id vgpus (fun vgpu ->
++                nested_parallel_map "VGPUs.activate" ~id vgpus (fun vgpu ->
+                     [VGPU_set_active (vgpu.Vgpu.id, true)]
+                 )
+-              ; parallel_map "PCIs.plug (SRIOV)" ~id pcis_sriov (fun pci ->
+-                    [PCI_plug (pci.Pci.id, false)]
++              ; nested_parallel_map "PCIs.plug (SRIOV)" ~id pcis_sriov
++                  (fun pci -> [PCI_plug (pci.Pci.id, false)]
+                 )
+               ]
+           ]
+@@ -1870,56 +1908,9 @@ let rec perform_atomic ~progress_callback ?result (op : atomic)
+         (Printexc.to_string e)
+   )
+   | Parallel (_id, description, atoms) ->
+-      (* parallel_id is a unused unique name prefix for a parallel worker queue *)
+-      let parallel_id =
+-        Printf.sprintf "Parallel:task=%s.atoms=%d.(%s)"
+-          (Xenops_task.id_of_handle t)
+-          (List.length atoms) description
+-      in
+-      let with_tracing = id_with_tracing parallel_id t in
+-      debug "begin_%s" parallel_id ;
+-      let task_list =
+-        queue_atomics_and_wait ~progress_callback ~max_parallel_atoms:10
+-          with_tracing parallel_id atoms
+-      in
+-      debug "end_%s" parallel_id ;
+-      (* make sure that we destroy all the parallel tasks that finished *)
+-      let errors =
+-        List.map
+-          (fun (id, task_handle, task_state) ->
+-            match task_state with
+-            | Some (Task.Completed _) ->
+-                TASK.destroy' id ; None
+-            | Some (Task.Failed e) ->
+-                TASK.destroy' id ;
+-                let e =
+-                  match Rpcmarshal.unmarshal Errors.error.Rpc.Types.ty e with
+-                  | Ok x ->
+-                      Xenopsd_error x
+-                  | Error (`Msg x) ->
+-                      internal_error "Error unmarshalling failure: %s" x
+-                in
+-                Some e
+-            | None | Some (Task.Pending _) ->
+-                (* Because pending tasks are filtered out in
+-                   queue_atomics_and_wait with task_ended the second case will
+-                   never be encountered. The previous boolean used in
+-                   event_wait was enough to express the possible cases *)
+-                let err_msg =
+-                  Printf.sprintf "Timed out while waiting on task %s (%s)" id
+-                    (Xenops_task.get_dbg task_handle)
+-                in
+-                error "%s" err_msg ;
+-                Xenops_task.cancel task_handle ;
+-                Some (Xenopsd_error (Internal_error err_msg))
+-          )
+-          task_list
+-      in
+-      (* if any error was present, raise first one, so that
+-         trigger_cleanup_after_failure is called *)
+-      List.iter
+-        (fun err -> match err with None -> () | Some e -> raise e)
+-        errors
++      parallel_atomic ~progress_callback ~description ~nested:false atoms t
++  | Nested_parallel (_id, description, atoms) ->
++      parallel_atomic ~progress_callback ~description ~nested:true atoms t
+   | Serial (_, _, atoms) ->
+       List.iter (Fun.flip (perform_atomic ~progress_callback) t) atoms
+   | VIF_plug id ->
+@@ -2325,7 +2316,64 @@ let rec perform_atomic ~progress_callback ?result (op : atomic)
+       debug "VM.soft_reset %s" id ;
+       B.VM.soft_reset t (VM_DB.read_exn id)
+ 
+-and queue_atomic_int ~progress_callback dbg id op =
++and parallel_atomic ~progress_callback ~description ~nested atoms t =
++  (* parallel_id is a unused unique name prefix for a parallel worker queue *)
++  let redirector =
++    if nested then
++      Redirector.nested_parallel_queues
++    else
++      Redirector.parallel_queues
++  in
++  let parallel_id =
++    Printf.sprintf "%s:task=%s.atoms=%d.(%s)"
++      (Redirector.to_string redirector)
++      (Xenops_task.id_of_handle t)
++      (List.length atoms) description
++  in
++  let with_tracing = id_with_tracing parallel_id t in
++  debug "begin_%s" parallel_id ;
++  let task_list =
++    queue_atomics_and_wait ~progress_callback ~max_parallel_atoms:10
++      with_tracing parallel_id atoms redirector
++  in
++  debug "end_%s" parallel_id ;
++  (* make sure that we destroy all the parallel tasks that finished *)
++  let errors =
++    List.map
++      (fun (id, task_handle, task_state) ->
++        match task_state with
++        | Some (Task.Completed _) ->
++            TASK.destroy' id ; None
++        | Some (Task.Failed e) ->
++            TASK.destroy' id ;
++            let e =
++              match Rpcmarshal.unmarshal Errors.error.Rpc.Types.ty e with
++              | Ok x ->
++                  Xenopsd_error x
++              | Error (`Msg x) ->
++                  internal_error "Error unmarshalling failure: %s" x
++            in
++            Some e
++        | None | Some (Task.Pending _) ->
++            (* Because pending tasks are filtered out in
++                queue_atomics_and_wait with task_ended the second case will
++                never be encountered. The previous boolean used in
++                event_wait was enough to express the possible cases *)
++            let err_msg =
++              Printf.sprintf "Timed out while waiting on task %s (%s)" id
++                (Xenops_task.get_dbg task_handle)
++            in
++            error "%s" err_msg ;
++            Xenops_task.cancel task_handle ;
++            Some (Xenopsd_error (Internal_error err_msg))
++      )
++      task_list
++  in
++  (* if any error was present, raise first one, so that
++      trigger_cleanup_after_failure is called *)
++  List.iter (fun err -> match err with None -> () | Some e -> raise e) errors
++
++and queue_atomic_int ~progress_callback dbg id op redirector =
+   let task =
+     Xenops_task.add tasks dbg
+       (let r = ref None in
+@@ -2334,10 +2382,12 @@ and queue_atomic_int ~progress_callback dbg id op =
+          !r
+       )
+   in
+-  Redirector.push Redirector.parallel_queues id (Atomic op, task) ;
++  debug "Adding to %s queues" (Redirector.to_string redirector) ;
++  Redirector.push redirector id (Atomic op, task) ;
+   task
+ 
+-and queue_atomics_and_wait ~progress_callback ~max_parallel_atoms dbg id ops =
++and queue_atomics_and_wait ~progress_callback ~max_parallel_atoms dbg id ops
++    redirector =
+   let from = Updates.last_id dbg updates in
+   Xenops_utils.chunks max_parallel_atoms ops
+   |> List.mapi (fun chunk_idx ops ->
+@@ -2350,7 +2400,9 @@ and queue_atomics_and_wait ~progress_callback ~max_parallel_atoms dbg id ops =
+                let atom_id =
+                  Printf.sprintf "%s.chunk=%d.atom=%d" id chunk_idx atom_idx
+                in
+-               (queue_atomic_int ~progress_callback dbg atom_id op, op)
++               ( queue_atomic_int ~progress_callback dbg atom_id op redirector
++               , op
++               )
+              )
+              ops
+          in
+@@ -2522,7 +2574,9 @@ and trigger_cleanup_after_failure_atom op t =
+       immediate_operation dbg id (VM_check_state id)
+   | Best_effort op ->
+       trigger_cleanup_after_failure_atom op t
+-  | Parallel (_id, _description, ops) | Serial (_id, _description, ops) ->
++  | Parallel (_id, _description, ops)
++  | Nested_parallel (_id, _description, ops)
++  | Serial (_id, _description, ops) ->
+       List.iter (fun op -> trigger_cleanup_after_failure_atom op t) ops
+   | VM_rename (id1, id2, _) ->
+       immediate_operation dbg id1 (VM_check_state id1) ;
+diff --git a/quality-gate.sh b/quality-gate.sh
+index e59b8e40c..55fc69b98 100755
+--- a/quality-gate.sh
++++ b/quality-gate.sh
+@@ -44,7 +44,7 @@ mli-files () {
+ }
+ 
+ structural-equality () {
+-  N=9
++  N=7
+   EQ=$(git grep -r --count ' == ' -- '**/*.ml' ':!ocaml/sdk-gen/**/*.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)
+   if [ "$EQ" -eq "$N" ]; then
+     echo "OK counted $EQ usages of ' == '"

--- a/SOURCES/0015-CA-409510-Give-a-warning-if-atoms-nested-incorrectly.patch
+++ b/SOURCES/0015-CA-409510-Give-a-warning-if-atoms-nested-incorrectly.patch
@@ -1,0 +1,66 @@
+From fe6b0a6be2318e98d0ea77accd65d15060589ec1 Mon Sep 17 00:00:00 2001
+From: Steven Woods <steven.woods@cloud.com>
+Date: Mon, 19 May 2025 16:28:23 +0100
+Subject: [PATCH] CA-409510: Give a warning if atoms nested incorrectly
+
+This is a stopgap until we add compile-time constraints on the nesting,
+by for example using a polymorphic variant.
+
+Signed-off-by: Steven Woods <steven.woods@cloud.com>
+---
+ ocaml/xenopsd/lib/xenops_server.ml | 34 ++++++++++++++++++++++++++++--
+ 1 file changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/ocaml/xenopsd/lib/xenops_server.ml b/ocaml/xenopsd/lib/xenops_server.ml
+index 65f9b4fc4..2357bd6b5 100644
+--- a/ocaml/xenopsd/lib/xenops_server.ml
++++ b/ocaml/xenopsd/lib/xenops_server.ml
+@@ -1907,9 +1907,11 @@ let rec perform_atomic ~progress_callback ?result (op : atomic)
+       debug "Ignoring error during best-effort operation: %s"
+         (Printexc.to_string e)
+   )
+-  | Parallel (_id, description, atoms) ->
++  | Parallel (_id, description, atoms) as atom ->
++      check_nesting atom ;
+       parallel_atomic ~progress_callback ~description ~nested:false atoms t
+-  | Nested_parallel (_id, description, atoms) ->
++  | Nested_parallel (_id, description, atoms) as atom ->
++      check_nesting atom ;
+       parallel_atomic ~progress_callback ~description ~nested:true atoms t
+   | Serial (_, _, atoms) ->
+       List.iter (Fun.flip (perform_atomic ~progress_callback) t) atoms
+@@ -2316,6 +2318,34 @@ let rec perform_atomic ~progress_callback ?result (op : atomic)
+       debug "VM.soft_reset %s" id ;
+       B.VM.soft_reset t (VM_DB.read_exn id)
+ 
++and check_nesting atom =
++  let msg_prefix = "Nested atomics error" in
++  let rec check_nesting_inner found_parallel found_nested = function
++    | Parallel (_, _, rem) ->
++        if found_parallel then (
++          warn
++            "%s: Two or more Parallel atoms found, use Nested_parallel for the \
++             inner atom"
++            msg_prefix ;
++          true
++        ) else
++          List.exists (check_nesting_inner true found_nested) rem
++    | Nested_parallel (_, _, rem) ->
++        if found_nested then (
++          warn
++            "%s: Two or more Nested_parallel atoms found, there should only be \
++             one layer of nesting"
++            msg_prefix ;
++          true
++        ) else
++          List.exists (check_nesting_inner found_parallel true) rem
++    | Serial (_, _, rem) ->
++        List.exists (check_nesting_inner found_parallel found_nested) rem
++    | _ ->
++        false
++  in
++  ignore @@ check_nesting_inner false false atom
++
+ and parallel_atomic ~progress_callback ~description ~nested atoms t =
+   (* parallel_id is a unused unique name prefix for a parallel worker queue *)
+   let redirector =

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 25.6.0
-Release: 1.5%{?xsrel}%{?dist}
+Release: 1.6%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -98,8 +98,13 @@ Patch1011: 0011-Check-that-there-are-no-changes-during-SR.scan.patch
 # Merged upstream, will be in v25.17.0
 Patch1012: 0012-xapi_guest_agent-Update-xenstore-keys-for-Windows-PV.patch
 
-# Posted upstream: https://github.com/xapi-project/xen-api/pull/6454
+# Modified version merged upstream in v25.18.0: https://github.com/xapi-project/xen-api/pull/6454
 Patch1013: 0013-xapi_xenops-Try-to-avoid-a-race-during-suspend.patch
+
+# Backports:
+# Merged upstream, will be in v25.20.0: https://github.com/xapi-project/xen-api/pull/6469
+Patch1014: 0014-CA-409510-Make-xenopsd-nested-Parallel-atoms-explici.patch
+Patch1015: 0015-CA-409510-Give-a-warning-if-atoms-nested-incorrectly.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1416,6 +1421,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Tue May 20 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 25.6.0-1.6
+- Fix a deadlock in xenopsd due to atom nesting
+
 * Tue May 13 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 25.6.0-1.5
 - Remove pvsproxy.service from the list of units restarted on xcp-rrdd update
 


### PR DESCRIPTION
Upstream fixed a deadlock seen in production:
https://github.com/xapi-project/xen-api/pull/6469

We didn't encounter it yet but let's backport it sooner rather than later.