### PR TITLE
Print what capabilities are missing when migration fails

### DIFF
--- a/SOURCES/0009-xapi_vm_migrate-share-function-to-check-capabilities.patch
+++ b/SOURCES/0009-xapi_vm_migrate-share-function-to-check-capabilities.patch
@@ -1,0 +1,62 @@
+From c7196f2dd1c32adcf3b0b1dd36aaf61897d6e942 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 19 Dec 2025 12:06:06 +0000
+Subject: [PATCH 09/10] xapi_vm_migrate: share function to check capabilities
+
+The error is insufficient to know what capabilities are missing,
+consolidating code before the change is useful
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_vm_migrate.ml | 22 ++++++++++------------
+ 1 file changed, 10 insertions(+), 12 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_migrate.ml b/ocaml/xapi/xapi_vm_migrate.ml
+index 3e147054e..374201466 100644
+--- a/ocaml/xapi/xapi_vm_migrate.ml
++++ b/ocaml/xapi/xapi_vm_migrate.ml
+@@ -160,19 +160,21 @@ end))
+ 
+ open Storage_interface
+ 
++let supported_on ~ops sr sr_features =
++  let open Smint.Feature in
++  if not (List.for_all (fun op -> has_capability op sr_features) ops) then
++    let msg = [Ref.string_of sr] in
++    raise Api_errors.(Server_error (sr_does_not_support_migration, msg))
++
+ let assert_sr_support_operations ~__context ~vdi_map ~remote ~local_ops
+     ~remote_ops =
+   let op_supported_on_source_sr vdi ops =
+-    let open Smint.Feature in
+-    (* Check VDIs must not be present on SR which doesn't have required capability *)
++    (* Check VDIs must not be present on SR which doesn't have required
++       capability *)
+     let source_sr = Db.VDI.get_SR ~__context ~self:vdi in
+     let sr_record = Db.SR.get_record_internal ~__context ~self:source_sr in
+     let sr_features = Xapi_sr_operations.features_of_sr ~__context sr_record in
+-    if not (List.for_all (fun op -> has_capability op sr_features) ops) then
+-      raise
+-        (Api_errors.Server_error
+-           (Api_errors.sr_does_not_support_migration, [Ref.string_of source_sr])
+-        )
++    supported_on ~ops source_sr sr_features
+   in
+   let op_supported_on_dest_sr sr ops sm_record remote =
+     let open Smint.Feature in
+@@ -187,11 +189,7 @@ let assert_sr_support_operations ~__context ~vdi_map ~remote ~local_ops
+       | _ ->
+           []
+     in
+-    if not (List.for_all (fun op -> has_capability op sm_features) ops) then
+-      raise
+-        (Api_errors.Server_error
+-           (Api_errors.sr_does_not_support_migration, [Ref.string_of sr])
+-        )
++    supported_on ~ops sr sm_features
+   in
+   let is_sr_matching local_vdi_ref remote_sr_ref =
+     let source_sr_ref = Db.VDI.get_SR ~__context ~self:local_vdi_ref in
+-- 
+2.52.0
+

--- a/SOURCES/0010-xapi_vm_migrate-add-capabilities-to-migration-not-su.patch
+++ b/SOURCES/0010-xapi_vm_migrate-add-capabilities-to-migration-not-su.patch
@@ -1,0 +1,52 @@
+From 5bf2fb7064057dadb7b43181a09397898f375295 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 19 Dec 2025 12:17:23 +0000
+Subject: [PATCH 10/10] xapi_vm_migrate: add capabilities to migration not
+ supported by sr error
+
+The error does not make it clear at all what are the capabilities that
+are stopping it from supporting migration, which makes debugging issues
+difficult, add a string that contains them. This can be easily ignored
+by default in clients, but the information is easily available if needed.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/idl/datamodel_errors.ml | 2 +-
+ ocaml/xapi/xapi_vm_migrate.ml | 8 ++++++--
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/ocaml/idl/datamodel_errors.ml b/ocaml/idl/datamodel_errors.ml
+index 361a33270..c1b1f09e2 100644
+--- a/ocaml/idl/datamodel_errors.ml
++++ b/ocaml/idl/datamodel_errors.ml
+@@ -1059,7 +1059,7 @@ let _ =
+     ~doc:"The VDI mirroring cannot be performed" () ;
+   error Api_errors.too_many_storage_migrates ["number"]
+     ~doc:"You reached the maximal number of concurrently migrating VMs." () ;
+-  error Api_errors.sr_does_not_support_migration ["sr"]
++  error Api_errors.sr_does_not_support_migration ["sr"; "capabilities"]
+     ~doc:"Cannot migrate a VDI to or from an SR that doesn't support migration."
+     () ;
+   error Api_errors.vm_failed_shutdown_ack ["vm"]
+diff --git a/ocaml/xapi/xapi_vm_migrate.ml b/ocaml/xapi/xapi_vm_migrate.ml
+index 374201466..5883eb821 100644
+--- a/ocaml/xapi/xapi_vm_migrate.ml
++++ b/ocaml/xapi/xapi_vm_migrate.ml
+@@ -162,8 +162,12 @@ open Storage_interface
+ 
+ let supported_on ~ops sr sr_features =
+   let open Smint.Feature in
+-  if not (List.for_all (fun op -> has_capability op sr_features) ops) then
+-    let msg = [Ref.string_of sr] in
++  let missing =
++    List.filter (fun op -> not (has_capability op sr_features)) ops
++  in
++  if missing <> [] then
++    let missing = List.map capability_to_string missing |> String.concat ";" in
++    let msg = [Ref.string_of sr; missing] in
+     raise Api_errors.(Server_error (sr_does_not_support_migration, msg))
+ 
+ let assert_sr_support_operations ~__context ~vdi_map ~remote ~local_ops
+-- 
+2.52.0
+

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -26,7 +26,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 25.33.1
-Release: 2.2%{?xsrel}%{?dist}
+Release: 2.3%{?xsrel}%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -97,6 +97,10 @@ Patch1007: 0007-ocaml-libs-Check-if-blocks-are-filled-with-zeros-in-.patch
 
 # Upstream PR: https://github.com/xapi-project/xen-api/pull/6823
 Patch1008: 0008-xenops-Fix-migrate-parameter-ordering.patch
+
+#Upstream PR: https://github.com/xapi-project/xen-api/pull/6829
+Patch1009: 0009-xapi_vm_migrate-share-function-to-check-capabilities.patch
+Patch1010: 0010-xapi_vm_migrate-add-capabilities-to-migration-not-su.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1479,6 +1483,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Tue Jan 13 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 25.33.1-2.3
+- Print what capabilities are missing when migration fails
+
 * Thu Jan 08 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 25.33.1-2.2
 - Fix parameter ordering during migration causing VMs to not balloon down
 


### PR DESCRIPTION
There's a user with migrations failed due to the SM backend not supporting enough capabilities, but the SM reports it does when it prints its capabilities. We need to add more information in the logs to understand why this is happening.