### PR TITLE
Switch to optimized data cluster format for VHD and QCOW

### DIFF
--- a/SOURCES/0007-qcow-stream-tool-Switch-read_headers-to-the-interval.patch
+++ b/SOURCES/0007-qcow-stream-tool-Switch-read_headers-to-the-interval.patch
@@ -1,0 +1,57 @@
+From 5d96e5b208990973a527ba3dea37c861ba51dd87 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 4 Feb 2026 13:29:40 +0000
+Subject: [PATCH] qcow-stream-tool: Switch read_headers to the interval-based
+ sparse format
+
+Qcow_stream now uses Qcow_mapping to store information on allocated clusters,
+which offers .to_interval_seq, outputting a list of pairs representing
+intervals of allocated virtual clusters.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/qcow-stream-tool/qcow_stream_tool.ml | 23 +++++++++++-----------
+ 1 file changed, 11 insertions(+), 12 deletions(-)
+
+diff --git a/ocaml/qcow-stream-tool/qcow_stream_tool.ml b/ocaml/qcow-stream-tool/qcow_stream_tool.ml
+index b8605c2f4..ebcc39950 100644
+--- a/ocaml/qcow-stream-tool/qcow_stream_tool.ml
++++ b/ocaml/qcow-stream-tool/qcow_stream_tool.ml
+@@ -12,16 +12,15 @@ module Impl = struct
+       let* virtual_size, cluster_bits, _, data_cluster_map =
+         Qcow_stream.start_stream_decode fd
+       in
+-      (* TODO: List.map becomes tail-recursive in OCaml 5.1, and could be used here instead *)
+       let clusters =
+-        data_cluster_map
+-        |> Qcow_types.Cluster.Map.to_seq
+-        |> Seq.map (fun (_, virt_address) ->
+-            let ( >> ) = Int64.shift_right_logical in
+-            let address =
+-              Int64.to_int (virt_address >> Int32.to_int cluster_bits)
+-            in
+-            `Int address
++        Qcow_mapping.to_interval_seq data_cluster_map
++          (Int64.of_int32 cluster_bits)
++        |> Seq.map (fun (left_cluster, right_cluster) ->
++            `List
++              [
++                `Int (Int64.to_int left_cluster)
++              ; `Int (Int64.to_int right_cluster)
++              ]
+         )
+         |> List.of_seq
+       in
+@@ -64,9 +63,9 @@ module Cli = struct
+ 
+   let read_headers_cmd =
+     let doc =
+-      "Determine allocated clusters by parsing qcow2 file at the provided \
+-       path. Returns JSON like the following: {'virtual_size': X, \
+-       'cluster_bits': Y, 'data_clusters': [1,2,3]}"
++      "Determine intervals of allocated clusters by parsing qcow2 file at the \
++       provided path. Returns JSON like the following: {'virtual_size': X, \
++       'cluster_bits': Y, 'data_clusters': [[1,13],[17,17],[19,272]]}"
+     in
+     let man = [`S "DESCRIPTION"; `P doc] in
+     Cmd.v

--- a/SOURCES/0008-xapi_globs-Add-vhd_legacy_blocks_format-feature-flag.patch
+++ b/SOURCES/0008-xapi_globs-Add-vhd_legacy_blocks_format-feature-flag.patch
@@ -1,0 +1,41 @@
+From 8066f85fa63696e4b8b4b7592c902cf085816da0 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 18 Feb 2026 15:28:20 +0000
+Subject: [PATCH] xapi_globs: Add vhd_legacy_blocks_format feature flag
+
+This allows to switch on the more efficient interval format later.
+(QCOW always uses the new format)
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/xapi/xapi_globs.ml | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/ocaml/xapi/xapi_globs.ml b/ocaml/xapi/xapi_globs.ml
+index 18aeba14d..c1db14af7 100644
+--- a/ocaml/xapi/xapi_globs.ml
++++ b/ocaml/xapi/xapi_globs.ml
+@@ -1149,6 +1149,10 @@ let validate_reusable_pool_session = ref false
+ let vm_sysprep_enabled = ref true
+ (* enable VM.sysprep API *)
+ 
++let vhd_legacy_blocks_format = ref true
++(* If false, uses an interval-based JSON blocks format for VHD instead of the
++   legacy format which includes all the allocated clusters *)
++
+ let vm_sysprep_wait = ref 5.0 (* seconds *)
+ 
+ let test_open = ref 0
+@@ -1876,6 +1880,12 @@ let other_options =
+     , (fun () -> string_of_float !vm_sysprep_wait)
+     , "Time in seconds to wait for VM to recognise inserted CD"
+     )
++  ; ( "vhd-legacy-blocks-format"
++    , Arg.Set vhd_legacy_blocks_format
++    , (fun () -> string_of_bool !vhd_legacy_blocks_format)
++    , "Choose whether legacy/sparse block format will be used for determining \
++       allocated VHD clusters"
++    )
+   ; ( "proxy_poll_period_timeout"
+     , Arg.Set_float proxy_poll_period_timeout
+     , (fun () -> string_of_float !proxy_poll_period_timeout)

--- a/SOURCES/0009-vhd-tool-Add-read_headers_interval-command.patch
+++ b/SOURCES/0009-vhd-tool-Add-read_headers_interval-command.patch
@@ -1,0 +1,217 @@
+From 9d40de7bd40a1fcf5a7fdb2958f15c8758f9e344 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 18 Feb 2026 15:45:19 +0000
+Subject: [PATCH] vhd-tool: Add read_headers_interval command
+
+This command returns a more efficient representation of allocated clusters
+(when compared to read_headers), utilizing a sparse interval format instead of
+returning every single allocated cluster.
+
+This is the more efficient option, decreasing the filesize and memory usage in
+vhd-tool, but it's currently under a feature flag, so it's added as a new
+command instead of replacing read_headers immediately.
+
+Cram test for read_headers is still passing, so this refactoring has preserved
+the legacy format.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/libs/vhd/vhd_format/f.ml  | 64 +++++++++++++++++++++++++--------
+ ocaml/libs/vhd/vhd_format/f.mli |  2 ++
+ ocaml/vhd-tool/cli/main.ml      | 26 +++++++++++---
+ ocaml/vhd-tool/src/impl.ml      |  8 +++--
+ ocaml/vhd-tool/src/impl.mli     |  2 +-
+ 5 files changed, 79 insertions(+), 23 deletions(-)
+
+diff --git a/ocaml/libs/vhd/vhd_format/f.ml b/ocaml/libs/vhd/vhd_format/f.ml
+index 4285d2fab..c3bf4dce4 100644
+--- a/ocaml/libs/vhd/vhd_format/f.ml
++++ b/ocaml/libs/vhd/vhd_format/f.ml
+@@ -2903,24 +2903,10 @@ functor
+ 
+       let raw ?from (vhd : fd Vhd.t) = raw_common ?from vhd
+ 
+-      let vhd_blocks_to_json (t : fd Vhd.t) =
++      let vhd_blocks_to_json_aux (t : fd Vhd.t) blocks =
+         let block_size_sectors_shift =
+           t.Vhd.header.Header.block_size_sectors_shift
+         in
+-        let max_table_entries = Vhd.used_max_table_entries t in
+-
+-        let include_block = include_block None t in
+-
+-        let blocks =
+-          Seq.init max_table_entries Fun.id
+-          |> Seq.filter_map (fun i ->
+-              if include_block i then
+-                Some (`Int i)
+-              else
+-                None
+-          )
+-          |> List.of_seq
+-        in
+         let json =
+           `Assoc
+             [
+@@ -2934,6 +2920,52 @@ functor
+         let json_string = Yojson.to_string json in
+         print_string json_string ; return ()
+ 
++      let vhd_blocks_to_json (t : fd Vhd.t) =
++        let max_table_entries = Vhd.used_max_table_entries t in
++        let blocks =
++          Seq.init max_table_entries Fun.id
++          |> Seq.filter_map (fun i ->
++              if include_block None t i then
++                Some (`Int i)
++              else
++                None
++          )
++          |> List.of_seq
++        in
++        vhd_blocks_to_json_aux t blocks
++
++      let vhd_blocks_to_json_interval (t : fd Vhd.t) =
++        let max_table_entries = Vhd.used_max_table_entries t in
++        let blocks, last_block =
++          Seq.init max_table_entries Fun.id
++          |> Seq.fold_left
++               (fun (acc, left_block) i ->
++                 if include_block None t i then
++                   match left_block with
++                   | Some _ ->
++                       (acc, left_block)
++                   | None ->
++                       (acc, Some i)
++                 else
++                   match left_block with
++                   | Some x ->
++                       (`List [`Int x; `Int (i - 1)] :: acc, None)
++                   | None ->
++                       (acc, None)
++               )
++               ([], None)
++        in
++        (* Close off the interval we were tracking we ran off the end of the seq *)
++        let blocks =
++          match last_block with
++          | Some x ->
++              `List [`Int x; `Int (max_table_entries - 1)] :: blocks
++          | None ->
++              blocks
++        in
++        let blocks = List.rev blocks in
++        vhd_blocks_to_json_aux t blocks
++
+       let vhd_common ?from ?raw ?(emit_batmap = false) (t : fd Vhd.t) =
+         let block_size_sectors_shift =
+           t.Vhd.header.Header.block_size_sectors_shift
+@@ -3173,6 +3205,8 @@ functor
+         Vhd_input.vhd_common ?from ~raw vhd
+ 
+       let blocks_json = Vhd_input.vhd_blocks_to_json
++
++      let blocks_json_interval = Vhd_input.vhd_blocks_to_json_interval
+     end
+ 
+     (* Create a VHD stream from data on t, using `include_block` guide us which blocks have data *)
+diff --git a/ocaml/libs/vhd/vhd_format/f.mli b/ocaml/libs/vhd/vhd_format/f.mli
+index a4b4e9761..fdeca3ad1 100644
+--- a/ocaml/libs/vhd/vhd_format/f.mli
++++ b/ocaml/libs/vhd/vhd_format/f.mli
+@@ -470,6 +470,8 @@ module From_file : functor (F : S.FILE) -> sig
+         [from] into [t] *)
+ 
+     val blocks_json : fd Vhd.t -> unit t
++
++    val blocks_json_interval : fd Vhd.t -> unit t
+   end
+ 
+   module Raw_input : sig
+diff --git a/ocaml/vhd-tool/cli/main.ml b/ocaml/vhd-tool/cli/main.ml
+index a4043b52b..e131879c4 100644
+--- a/ocaml/vhd-tool/cli/main.ml
++++ b/ocaml/vhd-tool/cli/main.ml
+@@ -385,19 +385,34 @@ let stream_cmd =
+   , Cmd.info "stream" ~sdocs:_common_options ~doc ~man
+   )
+ 
++let vhd_source =
++  let doc = Printf.sprintf "Path to the VHD file" in
++  Arg.(required & pos 0 (some file) None & info [] ~doc)
++
+ let read_headers_cmd =
+   let doc =
+     {|Parse VHD headers and output allocated blocks information in JSON format \
+      like: {"virtual_size": X, "cluster_bits": X, "data_clusters": [1,2,3]}|}
+   in
+-  let source =
+-    let doc = Printf.sprintf "Path to the VHD file" in
+-    Arg.(required & pos 0 (some file) None & info [] ~doc)
+-  in
+-  ( Term.(ret (const Impl.read_headers $ common_options_t $ source))
++  ( Term.(
++      ret
++        (const (Impl.read_headers ~legacy:true) $ common_options_t $ vhd_source)
++    )
+   , Cmd.info "read_headers" ~sdocs:_common_options ~doc
+   )
+ 
++let read_headers_interval_cmd =
++  let doc =
++    {|Parse VHD headers and output allocated blocks intervals information in JSON format \
++     like: {"virtual_size": X, "cluster_bits": X, "data_clusters": [[1,13],[17,17],[19,272]]|}
++  in
++  ( Term.(
++      ret
++        (const (Impl.read_headers ~legacy:false) $ common_options_t $ vhd_source)
++    )
++  , Cmd.info "read_headers_interval" ~sdocs:_common_options ~doc
++  )
++
+ let cmds =
+   [
+     info_cmd
+@@ -408,6 +423,7 @@ let cmds =
+   ; serve_cmd
+   ; stream_cmd
+   ; read_headers_cmd
++  ; read_headers_interval_cmd
+   ]
+   |> List.map (fun (t, i) -> Cmd.v i t)
+ 
+diff --git a/ocaml/vhd-tool/src/impl.ml b/ocaml/vhd-tool/src/impl.ml
+index 530c915b8..6c7595351 100644
+--- a/ocaml/vhd-tool/src/impl.ml
++++ b/ocaml/vhd-tool/src/impl.ml
+@@ -1168,11 +1168,15 @@ let stream_t common args ?(progress = no_progress_bar) () =
+     args.StreamCommon.tar_filename_prefix args.StreamCommon.good_ciphersuites
+     args.StreamCommon.verify_cert
+ 
+-let read_headers common source =
++let read_headers common source ~legacy =
+   let path = [Filename.dirname source] in
+   let thread =
+     retry common 3 (fun () -> Vhd_IO.openchain ~path source false) >>= fun t ->
+-    Vhd_IO.close t >>= fun () -> Hybrid_input.blocks_json t
++    Vhd_IO.close t >>= fun () ->
++    if legacy then
++      Hybrid_input.blocks_json t
++    else
++      Hybrid_input.blocks_json_interval t
+   in
+   Lwt_main.run thread ; `Ok ()
+ 
+diff --git a/ocaml/vhd-tool/src/impl.mli b/ocaml/vhd-tool/src/impl.mli
+index 13fe7ba68..d2adae5a9 100644
+--- a/ocaml/vhd-tool/src/impl.mli
++++ b/ocaml/vhd-tool/src/impl.mli
+@@ -36,7 +36,7 @@ val stream :
+   Common.t -> StreamCommon.t -> [> `Error of bool * string | `Ok of unit]
+ 
+ val read_headers :
+-  Common.t -> string -> [> `Error of bool * string | `Ok of unit]
++  Common.t -> string -> legacy:bool -> [> `Error of bool * string | `Ok of unit]
+ 
+ val serve :
+      Common.t

--- a/SOURCES/0010-vhd_qcow_parsing-Add-parse_header_interval-for-inter.patch
+++ b/SOURCES/0010-vhd_qcow_parsing-Add-parse_header_interval-for-inter.patch
@@ -1,0 +1,254 @@
+From 1d24ed7d39b076236170443450fcc51d481774a3 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 18 Feb 2026 16:03:38 +0000
+Subject: [PATCH] vhd_qcow_parsing: Add parse_header_interval for
+ interval-based headers
+
+Since the runtime feature flag vhd_legacy_blocks_format determines which block
+format is used to describe allocated VHD clusters, this requires duplicate
+parse_header_interval functions for VHD and QCOW.
+
+The right functions are selected in stream_vdi based on the feature flag.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/xapi/qcow_tool_wrapper.ml  |   4 ++
+ ocaml/xapi/qcow_tool_wrapper.mli |   2 +
+ ocaml/xapi/stream_vdi.ml         | 105 ++++++++++++++++++++++---------
+ ocaml/xapi/vhd_qcow_parsing.ml   |  23 ++++++-
+ ocaml/xapi/vhd_qcow_parsing.mli  |   2 +
+ ocaml/xapi/vhd_tool_wrapper.ml   |  15 ++++-
+ 6 files changed, 119 insertions(+), 32 deletions(-)
+
+diff --git a/ocaml/xapi/qcow_tool_wrapper.ml b/ocaml/xapi/qcow_tool_wrapper.ml
+index c04617f4f..24f396f0d 100644
+--- a/ocaml/xapi/qcow_tool_wrapper.ml
++++ b/ocaml/xapi/qcow_tool_wrapper.ml
+@@ -45,6 +45,10 @@ let parse_header qcow_path =
+   let pipe_reader = read_header qcow_path in
+   Vhd_qcow_parsing.parse_header pipe_reader
+ 
++let parse_header_interval qcow_path =
++  let pipe_reader = read_header qcow_path in
++  Vhd_qcow_parsing.parse_header_interval pipe_reader
++
+ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+     (path : string) (_size : Int64.t) =
+   let qcow_of_device =
+diff --git a/ocaml/xapi/qcow_tool_wrapper.mli b/ocaml/xapi/qcow_tool_wrapper.mli
+index c1c4a6426..16cede3bb 100644
+--- a/ocaml/xapi/qcow_tool_wrapper.mli
++++ b/ocaml/xapi/qcow_tool_wrapper.mli
+@@ -25,3 +25,5 @@ val send :
+   -> unit
+ 
+ val parse_header : string -> int * int list
++
++val parse_header_interval : string -> int * (int * int) list
+diff --git a/ocaml/xapi/stream_vdi.ml b/ocaml/xapi/stream_vdi.ml
+index 9b4e5bebd..cc61e958d 100644
+--- a/ocaml/xapi/stream_vdi.ml
++++ b/ocaml/xapi/stream_vdi.ml
+@@ -306,37 +306,86 @@ let send_one ofd (__context : Context.t) rpc session_id progress refresh_session
+           | Ok (Some (driver, path)) when driver = "vhd" || driver = "qcow2"
+             -> (
+             try
+-              (* Read backing file headers, then only read and write
+-                 allocated clusters from the bitmap *)
+-              let cluster_size, cluster_list =
+-                match driver with
+-                | "vhd" ->
+-                    Vhd_tool_wrapper.parse_header path
+-                | "qcow2" ->
+-                    Qcow_tool_wrapper.parse_header path
+-                | _ ->
+-                    failwith (Printf.sprintf "%s: unreachable" __FUNCTION__)
+-              in
+-              let set =
+-                get_allocated_chunks_from_clusters cluster_size cluster_list
+-              in
+-              (* First and last chunks are always written - it's a limitation
+-                 of the XVA format *)
+               let last_chunk =
+                 Int64.((to_int size - to_int chunk_size + 1) / to_int chunk_size)
+               in
+-              let set = set |> ChunkSet.add 0 |> ChunkSet.add last_chunk in
+-              ChunkSet.iter
+-                (fun this_chunk_no ->
+-                  let offset = Int64.(mul (of_int this_chunk_no) chunk_size) in
+-                  let _ =
+-                    write_chunk this_chunk_no offset
+-                      ~write_check:(fun _ _ -> true)
+-                      ~seek:true ~timeout_workaround:false
+-                  in
+-                  ()
+-                )
+-                set
++              if !Xapi_globs.vhd_legacy_blocks_format then
++                (* Read backing file headers, then only read and write
++                 allocated clusters from the bitmap *)
++                let cluster_size, cluster_list =
++                  match driver with
++                  | "vhd" ->
++                      Vhd_tool_wrapper.parse_header path
++                  | "qcow2" ->
++                      Qcow_tool_wrapper.parse_header path
++                  | _ ->
++                      failwith (Printf.sprintf "%s: unreachable" __FUNCTION__)
++                in
++                let set =
++                  get_allocated_chunks_from_clusters cluster_size cluster_list
++                in
++                (* First and last chunks are always written - it's a limitation
++                 of the XVA format *)
++                let set = set |> ChunkSet.add 0 |> ChunkSet.add last_chunk in
++                ChunkSet.iter
++                  (fun this_chunk_no ->
++                    let offset =
++                      Int64.(mul (of_int this_chunk_no) chunk_size)
++                    in
++                    let _ =
++                      write_chunk this_chunk_no offset
++                        ~write_check:(fun _ _ -> true)
++                        ~seek:true ~timeout_workaround:false
++                    in
++                    ()
++                  )
++                  set
++              else
++                let cluster_size, cluster_list =
++                  match driver with
++                  | "vhd" ->
++                      Vhd_tool_wrapper.parse_header_interval path
++                  | "qcow2" ->
++                      Qcow_tool_wrapper.parse_header_interval path
++                  | _ ->
++                      failwith (Printf.sprintf "%s: unreachable" __FUNCTION__)
++                in
++                let process_chunk chunk_no ~force =
++                  if force || (chunk_no <> 0 && chunk_no <> last_chunk) then
++                    let offset = Int64.(mul (of_int chunk_no) chunk_size) in
++                    let _ =
++                      write_chunk chunk_no offset
++                        ~write_check:(fun _ _ -> true)
++                        ~seek:true ~timeout_workaround:false
++                    in
++                    ()
++                in
++
++                process_chunk 0 ~force:true ;
++
++                let chunk_size = Int64.to_int chunk_size in
++                let chunks_in_cluster =
++                  (cluster_size + chunk_size - 1) / chunk_size
++                in
++                (* Iterate over allocated intervals, copying every cluster inside *)
++                List.iter
++                  (fun (cluster_no_left, cluster_no_right) ->
++                    let calc_chunk cluster =
++                      let cluster_offset = cluster * cluster_size in
++                      let chunk_no = cluster_offset / chunk_size in
++                      chunk_no
++                    in
++                    let left_chunk_no = calc_chunk cluster_no_left in
++                    let right_chunk_no =
++                      calc_chunk cluster_no_right + chunks_in_cluster - 1
++                    in
++                    for i = left_chunk_no to right_chunk_no do
++                      process_chunk i ~force:false
++                    done
++                  )
++                  cluster_list ;
++
++                process_chunk last_chunk ~force:true
+             with e ->
+               debug "%s: Falling back to reading the whole raw disk after %s"
+                 __FUNCTION__ (Printexc.to_string e) ;
+diff --git a/ocaml/xapi/vhd_qcow_parsing.ml b/ocaml/xapi/vhd_qcow_parsing.ml
+index 627f16bb0..0956b4d8f 100644
+--- a/ocaml/xapi/vhd_qcow_parsing.ml
++++ b/ocaml/xapi/vhd_qcow_parsing.ml
+@@ -44,7 +44,7 @@ let run_tool tool ?(replace_fds = []) ?input_fd ?output_fd
+       error "%s output: %s" tool out ;
+       raise (Api_errors.Server_error (Api_errors.vdi_io_error, [out]))
+ 
+-let parse_header pipe_reader =
++let parse_header_aux pipe_reader =
+   let ic = Unix.in_channel_of_descr pipe_reader in
+   let buf = Buffer.create 4096 in
+   let json = Yojson.Basic.from_channel ~buf ~fname:"header.json" ic in
+@@ -52,7 +52,28 @@ let parse_header pipe_reader =
+   let cluster_size =
+     1 lsl Yojson.Basic.Util.(member "cluster_bits" json |> to_int)
+   in
++  (cluster_size, json)
++
++let parse_header pipe_reader =
++  let cluster_size, json = parse_header_aux pipe_reader in
+   let cluster_list =
+     Yojson.Basic.Util.(member "data_clusters" json |> to_list |> List.map to_int)
+   in
+   (cluster_size, cluster_list)
++
++let parse_header_interval pipe_reader =
++  let cluster_size, json = parse_header_aux pipe_reader in
++  let cluster_list =
++    Yojson.Basic.Util.(
++      member "data_clusters" json
++      |> to_list
++      |> List.map (fun x ->
++          match to_list x with
++          | x :: y :: _ ->
++              (to_int x, to_int y)
++          | _ ->
++              raise (Invalid_argument "Invalid JSON")
++      )
++    )
++  in
++  (cluster_size, cluster_list)
+diff --git a/ocaml/xapi/vhd_qcow_parsing.mli b/ocaml/xapi/vhd_qcow_parsing.mli
+index 25417c0b9..2df479d92 100644
+--- a/ocaml/xapi/vhd_qcow_parsing.mli
++++ b/ocaml/xapi/vhd_qcow_parsing.mli
+@@ -22,3 +22,5 @@ val run_tool :
+   -> unit
+ 
+ val parse_header : Unix.file_descr -> int * int list
++
++val parse_header_interval : Unix.file_descr -> int * (int * int) list
+diff --git a/ocaml/xapi/vhd_tool_wrapper.ml b/ocaml/xapi/vhd_tool_wrapper.ml
+index 64afa6b45..a2faa5acc 100644
+--- a/ocaml/xapi/vhd_tool_wrapper.ml
++++ b/ocaml/xapi/vhd_tool_wrapper.ml
+@@ -116,9 +116,14 @@ let receive progress_cb format protocol (s : Unix.file_descr)
+   in
+   run_vhd_tool progress_cb args s s' path
+ 
+-let read_vhd_header path =
++let read_vhd_header path ~legacy =
+   let vhd_tool = !Xapi_globs.vhd_tool in
+-  let args = ["read_headers"; path] in
++  let args =
++    if legacy then
++      ["read_headers"; path]
++    else
++      ["read_headers_interval"; path]
++  in
+   let pipe_reader, pipe_writer = Unix.pipe ~cloexec:true () in
+ 
+   let progress_cb _ = () in
+@@ -137,9 +142,13 @@ let read_vhd_header path =
+   pipe_reader
+ 
+ let parse_header vhd_path =
+-  let pipe_reader = read_vhd_header vhd_path in
++  let pipe_reader = read_vhd_header vhd_path ~legacy:true in
+   Vhd_qcow_parsing.parse_header pipe_reader
+ 
++let parse_header_interval vhd_path =
++  let pipe_reader = read_vhd_header vhd_path ~legacy:false in
++  Vhd_qcow_parsing.parse_header_interval pipe_reader
++
+ let send progress_cb ?relative_to (protocol : string) (dest_format : string)
+     (s : Unix.file_descr) (path : string) (size : Int64.t) (prefix : string) =
+   let __FUN = __FUNCTION__ in

--- a/SOURCES/0011-python3-qcow2-to-stdout-Implement-Interval-for-check.patch
+++ b/SOURCES/0011-python3-qcow2-to-stdout-Implement-Interval-for-check.patch
@@ -1,0 +1,85 @@
+From 8250fe80d0a9ffd793189b9d44ce741c676d353f Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 4 Feb 2026 13:20:56 +0000
+Subject: [PATCH] python3/qcow2-to-stdout: Implement Interval for checking
+ sparse cluster allocation
+
+Instead of using a set with every individual allocated cluster index as a
+member, use a sorted list of intervals to verify if cluster is allocated - this
+uses much less memory and directly follows from the JSON format
+qcow-stream-tool and vhd-tool output now.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ python3/libexec/qcow2-to-stdout.py | 58 ++++++++++++++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+
+diff --git a/python3/libexec/qcow2-to-stdout.py b/python3/libexec/qcow2-to-stdout.py
+index 4ce1cc72b..1f876ec4e 100755
+--- a/python3/libexec/qcow2-to-stdout.py
++++ b/python3/libexec/qcow2-to-stdout.py
+@@ -91,6 +91,64 @@ def write_features(cluster, offset, data_file_name):
+         offset += 48
+ 
+ 
++class Interval:
++    """
++    Represents the allocated virtual cluster intervals in a sparse file
++    """
++    def __init__(self, lst):
++        self.intervals = lst
++        self.intervals.sort(key=lambda x: x[0])
++
++
++    def __contains__(self, cluster):
++        """
++        Checks if cluster is in one of the intervals, removes it from the
++        interval if true
++        """
++        # Check if cluster is within [min, max]
++        if self.intervals[-1][1] < cluster or self.intervals[0][0] > cluster:
++            return False
++
++        # Binary search for the interval that could contain the cluster
++        l = 0
++        h = len(self.intervals) - 1
++        while l <= h:
++            mid = (l + h) // 2
++            current = self.intervals[mid]
++
++            if cluster >= current[0] and cluster <= current[1]:
++                if cluster == current[0] and cluster == current[1]:
++                    # Remove the cluster from the interval
++                    del self.intervals[mid]
++                    return True
++
++                if cluster == current[0]:
++                    # Shrink interval from the left
++                    left = current[0] + 1
++                    right = current[1]
++                elif cluster == current[1]:
++                    # Shrink interval from the right
++                    left = current[0]
++                    right = current[1] - 1
++                else:
++                    # Split the original interval into two
++                    left = current[0]
++                    right = cluster
++                    self.intervals.insert(mid+1, [cluster+1, current[1]])
++
++                self.intervals[mid] = [left, right]
++                return True
++            elif cluster < current[0]:
++                h = mid - 1
++            elif cluster > current[1]:
++                l = mid + 1
++
++        return False
++
++    def __iter__(self):
++        return self.intervals.__iter__()
++
++
+ def write_qcow2_content(input_file, cluster_size, refcount_bits,
+                         data_file_name, data_file_raw, diff_file_name,
+                         virtual_size, nonzero_clusters,

--- a/SOURCES/0012-python3-qcow2-to-stdout-Switch-to-sparse-interval-fo.patch
+++ b/SOURCES/0012-python3-qcow2-to-stdout-Switch-to-sparse-interval-fo.patch
@@ -1,0 +1,65 @@
+From 8d47df8eb57fa2e76981e8505cb2ce26c24c0ada Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 4 Feb 2026 13:27:05 +0000
+Subject: [PATCH] python3/qcow2-to-stdout: Switch to sparse interval format for
+ nonzero_clusters
+
+nonzero_clusters no longer contain every single allocated cluster and instead
+are intervals of allocated clusters.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ python3/libexec/qcow2-to-stdout.py | 37 ++++++++++++++++--------------
+ 1 file changed, 20 insertions(+), 17 deletions(-)
+
+diff --git a/python3/libexec/qcow2-to-stdout.py b/python3/libexec/qcow2-to-stdout.py
+index 1f876ec4e..0f473e4a4 100755
+--- a/python3/libexec/qcow2-to-stdout.py
++++ b/python3/libexec/qcow2-to-stdout.py
+@@ -224,26 +224,29 @@ def write_qcow2_content(input_file, cluster_size, refcount_bits,
+             # In case input_file is bigger than diff_file_name, first check
+             # if clusters from diff_file_name differ, and then check if the
+             # rest contain data
+-            diff_nonzero_clusters_set = set(diff_nonzero_clusters)
+-            for cluster in nonzero_clusters:
+-                if cluster >= last_diff_cluster:
+-                    allocate_cluster(cluster)
+-                elif cluster in diff_nonzero_clusters_set:
+-                    # If a cluster has different data from the original_cluster
+-                    # then it must be allocated
+-                    cluster_data = os.pread(fd, cluster_size, cluster_size * cluster)
+-                    original_cluster = os.pread(diff_fd, cluster_size, cluster_size * cluster)
+-                    check_cluster_allocate(cluster, cluster_data, original_cluster)
+-                    diff_nonzero_clusters_set.remove(cluster)
+-                else:
+-                    allocate_cluster(cluster)
++            diff_nonzero_clusters_set = Interval(diff_nonzero_clusters)
++
++            for (cluster_left, cluster_right) in nonzero_clusters:
++                for cluster in range(cluster_left, cluster_right+1):
++                    if cluster >= last_diff_cluster:
++                        allocate_cluster(cluster)
++                    elif cluster in diff_nonzero_clusters_set:
++                        # If a cluster has different data from the original_cluster
++                        # then it must be allocated
++                        cluster_data = os.pread(fd, cluster_size, cluster_size * cluster)
++                        original_cluster = os.pread(diff_fd, cluster_size, cluster_size * cluster)
++                        check_cluster_allocate(cluster, cluster_data, original_cluster)
++                    else:
++                        allocate_cluster(cluster)
+ 
+             # These are not present in the original file
+-            for cluster in diff_nonzero_clusters_set:
+-                allocate_cluster(cluster)
++            for (cluster_left, cluster_right) in diff_nonzero_clusters_set:
++                for cluster in range(cluster_left, cluster_right+1):
++                    allocate_cluster(cluster)
+         else:
+-            for cluster in nonzero_clusters:
+-                allocate_cluster(cluster)
++            for (cluster_left, cluster_right) in nonzero_clusters:
++                for cluster in range(cluster_left, cluster_right+1):
++                    allocate_cluster(cluster)
+ 
+     else:
+         zero_cluster = bytes(cluster_size)

--- a/SOURCES/0013-xapi-qcow_tool_wrapper-Add-note-on-using-header-info.patch
+++ b/SOURCES/0013-xapi-qcow_tool_wrapper-Add-note-on-using-header-info.patch
@@ -1,0 +1,27 @@
+From 2a659abeb5bfae658086d534bb99eab0b29944d9 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Fri, 6 Feb 2026 09:05:27 +0000
+Subject: [PATCH] xapi/qcow_tool_wrapper: Add note on using header information
+ from VHD files
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/xapi/qcow_tool_wrapper.ml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/ocaml/xapi/qcow_tool_wrapper.ml b/ocaml/xapi/qcow_tool_wrapper.ml
+index 24f396f0d..947c5d2ba 100644
+--- a/ocaml/xapi/qcow_tool_wrapper.ml
++++ b/ocaml/xapi/qcow_tool_wrapper.ml
+@@ -60,6 +60,11 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+      to avoid reading all of the raw disk *)
+   let input_fd = Result.map read_header qcow_path |> Result.to_option in
+ 
++  (* TODO: If VHD headers are to be consulted as well, qcow2-to-stdout
++     needs to properly account for cluster_bits. Currently QCOW2 export
++     from VHD-backed VDIs will just revert to raw, without any
++     allocation accounting. *)
++
+   (* Parse the header of the VDI we are diffing against as well *)
+   let relative_to_qcow_path =
+     match relative_to with

--- a/SOURCES/0014-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
+++ b/SOURCES/0014-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
@@ -1,0 +1,22 @@
+From 1eff08ae05c491102c7a37769d65a1fd27d1d87c Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Fri, 6 Mar 2026 09:45:45 +0000
+Subject: [PATCH] xapi.conf: Switch to optimized data cluster format for VHD
+ and QCOW
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ scripts/xapi.conf | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/scripts/xapi.conf b/scripts/xapi.conf
+index 396e7da96..7fc2e8046 100644
+--- a/scripts/xapi.conf
++++ b/scripts/xapi.conf
+@@ -410,3 +410,6 @@ create-tools-sr = true
+ 
+ # Allows to modify the host's scheduler granularity
+ allow-host-sched-gran-modification = true
++
++# Switches to optimized data cluster format for VHD and QCOW
++vhd-legacy-blocks-format=false

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.3
-Release: 1%{?xsrel}.3%{?dist}
+Release: 1%{?xsrel}.4%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -98,6 +98,19 @@ Patch1004: 0004-xcp-ng-open-close-openflow-port.patch
 Patch1005: 0005-xcp-ng-update-db-tunnel-protocol-from-other-config.patch
 # Drop this when the rsyslog configuration changes
 Patch1006: 0006-xcp-ng-do-not-change-rsyslog-configuration.patch
+
+# Upstream PR: https://github.com/xapi-project/xen-api/pull/6895
+# Temporarily dropped unit test commits to avoid qemu-img build dependency,
+# flipped the xapi.conf switch
+Patch1007: 0007-qcow-stream-tool-Switch-read_headers-to-the-interval.patch
+Patch1008: 0008-xapi_globs-Add-vhd_legacy_blocks_format-feature-flag.patch
+Patch1009: 0009-vhd-tool-Add-read_headers_interval-command.patch
+Patch1010: 0010-vhd_qcow_parsing-Add-parse_header_interval-for-inter.patch
+Patch1011: 0011-python3-qcow2-to-stdout-Implement-Interval-for-check.patch
+Patch1012: 0012-python3-qcow2-to-stdout-Switch-to-sparse-interval-fo.patch
+Patch1013: 0013-xapi-qcow_tool_wrapper-Add-note-on-using-header-info.patch
+Patch1014: 0014-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
+
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1496,6 +1509,10 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Fri Mar 6 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 26.1.3-1.4
+- Switch to optimized data cluster format for VHD and QCOW,
+  reducing memory consumption on QCOW import
+
 * Tue Mar 03 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.3-1.3
 - Fix restart of metrics plugins on update
 


### PR DESCRIPTION
This reduces memory consumption during QCOW import.

Backport of upstream https://github.com/xapi-project/xen-api/pull/6895, with some modifications: temporarily drop the unit test commits to avoid `qemu-img` build dependency. Flip the `xapi.conf` switch to make vhd and qcow interval formats consistent - this is going to be the new default once XenServer tests it.

Relies on xs-opam PR to be merged beforehand: https://github.com/xcp-ng-rpms/xs-opam-repo/pull/15

Koji pre-build: https://koji.xcp-ng.org/buildinfo?buildID=5199