### PR TITLE
Fix QCOW2-backed VDI snapshots not being exported properly

### DIFF
--- a/SOURCES/0015-qcow_tool_wrapper-Don-t-read-headers-of-QCOW2-backed.patch
+++ b/SOURCES/0015-qcow_tool_wrapper-Don-t-read-headers-of-QCOW2-backed.patch
@@ -1,0 +1,89 @@
+From 567b4afacff970649a5bf68e02f50caeb66d9871 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 23 Mar 2026 15:59:20 +0000
+Subject: [PATCH] qcow_tool_wrapper: Don't read headers of QCOW2-backed VDIs on
+ export
+
+De-facto revert of 368596819c29c1682b2d07528b979615a094de00
+
+qcow-stream-tool needs to open the whole chain of VDIs, not just the current
+image. This breaks export of snapshots. Revert to fix quickly for now, this
+means QCOW2 export will not be sparse anymore.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/xapi/qcow_tool_wrapper.ml | 42 ++-------------------------------
+ ocaml/xapi/stream_vdi.ml        |  3 +--
+ 2 files changed, 3 insertions(+), 42 deletions(-)
+
+diff --git a/ocaml/xapi/qcow_tool_wrapper.ml b/ocaml/xapi/qcow_tool_wrapper.ml
+index 947c5d2ba..54f9d78c8 100644
+--- a/ocaml/xapi/qcow_tool_wrapper.ml
++++ b/ocaml/xapi/qcow_tool_wrapper.ml
+@@ -51,50 +51,12 @@ let parse_header_interval qcow_path =
+ 
+ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+     (path : string) (_size : Int64.t) =
+-  let qcow_of_device =
+-    Xapi_vdi_helpers.backing_file_of_device_with_driver ~driver:"qcow2"
+-  in
+-  let qcow_path = qcow_of_device path in
+-
+-  (* If VDI is backed by QCOW, parse the header to determine nonzero clusters
+-     to avoid reading all of the raw disk *)
+-  let input_fd = Result.map read_header qcow_path |> Result.to_option in
+-
+   (* TODO: If VHD headers are to be consulted as well, qcow2-to-stdout
+      needs to properly account for cluster_bits. Currently QCOW2 export
+      from VHD-backed VDIs will just revert to raw, without any
+      allocation accounting. *)
+-
+-  (* Parse the header of the VDI we are diffing against as well *)
+-  let relative_to_qcow_path =
+-    match relative_to with
+-    | Some x ->
+-        Result.to_option (qcow_of_device x)
+-    | None ->
+-        None
+-  in
+-  let diff_fd = Option.map read_header relative_to_qcow_path in
+-
+-  let unique_string = Uuidx.(to_string (make ())) in
+   let args =
+-    [path]
+-    @ (match relative_to with None -> [] | Some vdi -> ["--diff"; vdi])
+-    @ ( match relative_to_qcow_path with
+-      | None ->
+-          []
+-      | Some _ ->
+-          ["--json-header-diff"; unique_string]
+-      )
+-    @ match qcow_path with Error _ -> [] | Ok _ -> ["--json-header"]
++    [path] @ match relative_to with None -> [] | Some vdi -> ["--diff"; vdi]
+   in
+   let qcow_tool = !Xapi_globs.qcow_to_stdout in
+-  let replace_fds = Option.map (fun fd -> [(unique_string, fd)]) diff_fd in
+-  Xapi_stdext_pervasives.Pervasiveext.finally
+-    (fun () ->
+-      Vhd_qcow_parsing.run_tool qcow_tool progress_cb args ?input_fd
+-        ~output_fd:unix_fd ?replace_fds
+-    )
+-    (fun () ->
+-      Option.iter Unix.close input_fd ;
+-      Option.iter Unix.close diff_fd
+-    )
++  Vhd_qcow_parsing.run_tool qcow_tool progress_cb args ~output_fd:unix_fd
+diff --git a/ocaml/xapi/stream_vdi.ml b/ocaml/xapi/stream_vdi.ml
+index cc61e958d..16b330527 100644
+--- a/ocaml/xapi/stream_vdi.ml
++++ b/ocaml/xapi/stream_vdi.ml
+@@ -303,8 +303,7 @@ let send_one ofd (__context : Context.t) rpc session_id progress refresh_session
+             Xapi_vdi_helpers.backing_info_of_device dom0_path
+           in
+           match backing_info with
+-          | Ok (Some (driver, path)) when driver = "vhd" || driver = "qcow2"
+-            -> (
++          | Ok (Some (driver, path)) when driver = "vhd" -> (
+             try
+               let last_chunk =
+                 Int64.((to_int size - to_int chunk_size + 1) / to_int chunk_size)

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.3
-Release: 1%{?xsrel}.4%{?dist}
+Release: 1%{?xsrel}.5%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -110,6 +110,10 @@ Patch1011: 0011-python3-qcow2-to-stdout-Implement-Interval-for-check.patch
 Patch1012: 0012-python3-qcow2-to-stdout-Switch-to-sparse-interval-fo.patch
 Patch1013: 0013-xapi-qcow_tool_wrapper-Add-note-on-using-header-info.patch
 Patch1014: 0014-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
+
+# Temporary revert of read_headers optimization, to be resolved properly
+# by fixing qcow-stream-tool to consider the whole chain
+Patch1015: 0015-qcow_tool_wrapper-Don-t-read-headers-of-QCOW2-backed.patch
 
 
 %{?_cov_buildrequires}
@@ -1509,6 +1513,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Mon Mar 23 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 26.1.3-1.5
+- Fix QCOW2-backed VDI snapshots not being exported properly
+
 * Fri Mar 6 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 26.1.3-1.4
 - Switch to optimized data cluster format for VHD and QCOW,
   reducing memory consumption on QCOW import


### PR DESCRIPTION
This is a quick revert to fix the bug.