### PR TITLE
XCPNG-2470 : Rework local patch [xcp-ng] open/close openflow port to open the port conditionally

### DIFF
--- a/SOURCES/0004-xcp-ng-open-close-openflow-port.patch
+++ b/SOURCES/0004-xcp-ng-open-close-openflow-port.patch
@@ -1,4 +1,4 @@
-From de49984976741b027edbed1fa2331ae51540d033 Mon Sep 17 00:00:00 2001
+From d1bf4d44a2d6f52bd4891101da5e3b88e53f69ab Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 17:06:38 +0200
 Subject: [PATCH] [xcp-ng] open/close openflow port
@@ -8,27 +8,59 @@ The PR is here https://github.com/xapi-project/xen-api/pull/4188
 This patch does it until we have another way to do it.
 
 Signed-off-by: Guillaume <guillaume.thouvenin@vates.tech>
+
+XCPNG-2470 open/close openflow port only if needed
+XO uses `pool:other_config["xo:sdn-controller:of-method"]` to tell us the method used to manage OpenFlow rules.
+if it is "channel", XO will need port 6653 to be opened to directly manage rules, else it will use xapi plugin (via standard xe methods).
+
+Signed-off-by: Sebastien Marie <semarie@kapouay.eu.org>
 ---
- python3/plugins/openvswitch-config-update | 2 ++
- 1 file changed, 2 insertions(+)
+ python3/plugins/openvswitch-config-update | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/python3/plugins/openvswitch-config-update b/python3/plugins/openvswitch-config-update
-index 834788cf1..9c988db03 100755
+index 834788cf1..aa5a11d85 100755
 --- a/python3/plugins/openvswitch-config-update
 +++ b/python3/plugins/openvswitch-config-update
-@@ -74,6 +74,7 @@ def update(session, args):
-     if not controller and currentControllers:
-         delete_cacert()
-         runCmd([iptablectl, "close", "6640"])
+@@ -68,6 +68,13 @@ def update(session, args):
+             controller_protocol, controller_address, controller_port
+         )
+ 
++    # assume 'channel' if XO didn't set the property
++    of_method = pool["other_config"].get("xo:sdn-controller:of-method") or "channel"
++
++    # migration: unconditionnally close 6653 if not need
++    if of_method != "channel":
 +        runCmd([iptablectl, "close", "6653"])
++
+     ret_str = ""
+     currentControllers = vswitchCurrentControllers()
+ 
+@@ -83,7 +90,7 @@ def update(session, args):
+         delete_cacert()
          with contextlib.suppress(Exception):
              emergency_reset(session, None)
-         removeControllerCfg()
-@@ -274,6 +275,7 @@ def setControllerCfg(bootstrap, controller):
+-        setControllerCfg(bootstrap, controller)
++        setControllerCfg(bootstrap, controller, of_method)
+         new_controller = True
+         ret_str += "Successfully set controller to %s.  " % controller
+ 
+@@ -231,7 +238,7 @@ def removeControllerCfg():
+     vswitchCfgMod(["--", "del-manager", "--", "del-ssl"])
+ 
+ 
+-def setControllerCfg(bootstrap, controller):
++def setControllerCfg(bootstrap, controller, of_method):
+     # /etc/xensource/xapi-ssl.pem is mentioned twice below because it
+     # contains both the private key and the certificate.
+     if bootstrap:
+@@ -274,6 +281,9 @@ def setControllerCfg(bootstrap, controller):
                  controller,
              ]
          )
-+    runCmd([iptablectl, "open", "6653"])
++    # open 6653 only if we need it
++    if of_method == "channel":
++        runCmd([iptablectl, "open", "6653"])
  
  
  def composeController(protocol, controllerIP, tcpport):

--- a/SOURCES/0005-xcp-ng-update-db-tunnel-protocol-from-other-config.patch
+++ b/SOURCES/0005-xcp-ng-update-db-tunnel-protocol-from-other-config.patch
@@ -1,4 +1,4 @@
-From 3a436645ce4418878553e9384df5e5fa9e793b8d Mon Sep 17 00:00:00 2001
+From bcfe542fad5a8ead2e2e5ba50a6d8a57e20328e8 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 17:10:15 +0200
 Subject: [PATCH] [xcp-ng] update db tunnel protocol from other config

--- a/SOURCES/0006-xcp-ng-do-not-change-rsyslog-configuration.patch
+++ b/SOURCES/0006-xcp-ng-do-not-change-rsyslog-configuration.patch
@@ -1,4 +1,4 @@
-From 9457b3799dff894706b0a2f111d6bfedb6c33505 Mon Sep 17 00:00:00 2001
+From 5f1a2bf1194e6bcd544a287e19d0144f419a1c19 Mon Sep 17 00:00:00 2001
 From: Pau Ruiz Safont <pau.safont@vates.tech>
 Date: Sat, 18 Oct 2025 09:21:18 +0100
 Subject: [PATCH] [xcp-ng] do not change rsyslog configuration
@@ -17,8 +17,8 @@ Reverts commit 468eb75dddfea6db512a8bfb4860ff2042efab66.
 
 Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
 ---
- scripts/xe-syslog-reconfigure | 32 +++++++++++++++++++++++++++-----
- 1 file changed, 27 insertions(+), 5 deletions(-)
+ scripts/xe-syslog-reconfigure | 28 +++++++++++++++++++++++++---
+ 1 file changed, 25 insertions(+), 3 deletions(-)
 
 diff --git a/scripts/xe-syslog-reconfigure b/scripts/xe-syslog-reconfigure
 index fa5ad0b79..cc64a3030 100644
@@ -28,16 +28,11 @@ index fa5ad0b79..cc64a3030 100644
    shift
  done
  
--
--echo "# /etc/rsyslog.d/remote.conf is managed by xe-syslog-reconfigure (do not edit)" > /etc/rsyslog.d/remote.conf
--if [ $remote -eq 1 ]; then
--  echo "*.* @$host" >> /etc/rsyslog.d/remote.conf
 +if [ -r /etc/syslog.conf ]; then
 +  conf_file=/etc/syslog.conf
 +  service=syslog
- fi
- 
--systemctl restart rsyslog
++fi
++
 +if [ -r /etc/rsyslog.conf ]; then
 +  conf_file=/etc/rsyslog.conf
 +  service=rsyslog
@@ -52,13 +47,16 @@ index fa5ad0b79..cc64a3030 100644
 +  echo "Error: unable to determine syslog service" >&2
 +  exit 1
 +fi
-+
+ 
+-echo "# /etc/rsyslog.d/remote.conf is managed by xe-syslog-reconfigure (do not edit)" > /etc/rsyslog.d/remote.conf
 +sed -e '/^\*\.\*.*[@~]/ d' $conf_file >/etc/syslog.$$
-+if [ $remote -eq 1 ]; then
+ if [ $remote -eq 1 ]; then
+-  echo "*.* @$host" >> /etc/rsyslog.d/remote.conf
 +  echo -e "*.* @$host\n*.* ~" >>/etc/syslog.$$
 +else
 +  echo "*.* ~" >>/etc/syslog.$$
-+fi
-+
+ fi
+ 
+-systemctl restart rsyslog
 +[ -s /etc/syslog.$$ ] && mv -f /etc/syslog.$$ $conf_file
 +systemctl restart $service

--- a/SOURCES/0007-qcow-stream-tool-Switch-read_headers-to-the-interval.patch
+++ b/SOURCES/0007-qcow-stream-tool-Switch-read_headers-to-the-interval.patch
@@ -1,4 +1,4 @@
-From 5d96e5b208990973a527ba3dea37c861ba51dd87 Mon Sep 17 00:00:00 2001
+From 85fb02bebf56f371cd920ee57cb8db0d7f2fea63 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 4 Feb 2026 13:29:40 +0000
 Subject: [PATCH] qcow-stream-tool: Switch read_headers to the interval-based

--- a/SOURCES/0008-xapi_globs-Add-vhd_legacy_blocks_format-feature-flag.patch
+++ b/SOURCES/0008-xapi_globs-Add-vhd_legacy_blocks_format-feature-flag.patch
@@ -1,4 +1,4 @@
-From 8066f85fa63696e4b8b4b7592c902cf085816da0 Mon Sep 17 00:00:00 2001
+From 3ac21b330df5dc232045debcacce75fdc4609611 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 18 Feb 2026 15:28:20 +0000
 Subject: [PATCH] xapi_globs: Add vhd_legacy_blocks_format feature flag

--- a/SOURCES/0009-vhd-tool-Add-read_headers_interval-command.patch
+++ b/SOURCES/0009-vhd-tool-Add-read_headers_interval-command.patch
@@ -1,4 +1,4 @@
-From 9d40de7bd40a1fcf5a7fdb2958f15c8758f9e344 Mon Sep 17 00:00:00 2001
+From 92c6927bcaf79f65fe703474d7f982b736a30b01 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 18 Feb 2026 15:45:19 +0000
 Subject: [PATCH] vhd-tool: Add read_headers_interval command

--- a/SOURCES/0010-vhd_qcow_parsing-Add-parse_header_interval-for-inter.patch
+++ b/SOURCES/0010-vhd_qcow_parsing-Add-parse_header_interval-for-inter.patch
@@ -1,4 +1,4 @@
-From 1d24ed7d39b076236170443450fcc51d481774a3 Mon Sep 17 00:00:00 2001
+From 12cd403d6460b09b92c333d205e703ebf0eab093 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 18 Feb 2026 16:03:38 +0000
 Subject: [PATCH] vhd_qcow_parsing: Add parse_header_interval for

--- a/SOURCES/0011-python3-qcow2-to-stdout-Implement-Interval-for-check.patch
+++ b/SOURCES/0011-python3-qcow2-to-stdout-Implement-Interval-for-check.patch
@@ -1,4 +1,4 @@
-From 8250fe80d0a9ffd793189b9d44ce741c676d353f Mon Sep 17 00:00:00 2001
+From 9cab4070fb9a40fd60b45fcea3a0ebaaddab8767 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 4 Feb 2026 13:20:56 +0000
 Subject: [PATCH] python3/qcow2-to-stdout: Implement Interval for checking

--- a/SOURCES/0012-python3-qcow2-to-stdout-Switch-to-sparse-interval-fo.patch
+++ b/SOURCES/0012-python3-qcow2-to-stdout-Switch-to-sparse-interval-fo.patch
@@ -1,4 +1,4 @@
-From 8d47df8eb57fa2e76981e8505cb2ce26c24c0ada Mon Sep 17 00:00:00 2001
+From ea30332d1b388910d6cdc3efeb279863c7416c3c Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 4 Feb 2026 13:27:05 +0000
 Subject: [PATCH] python3/qcow2-to-stdout: Switch to sparse interval format for

--- a/SOURCES/0013-xapi-qcow_tool_wrapper-Add-note-on-using-header-info.patch
+++ b/SOURCES/0013-xapi-qcow_tool_wrapper-Add-note-on-using-header-info.patch
@@ -1,4 +1,4 @@
-From 2a659abeb5bfae658086d534bb99eab0b29944d9 Mon Sep 17 00:00:00 2001
+From 4f8775c2cbae5988d5dfa34443b523e48a7cfd98 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Fri, 6 Feb 2026 09:05:27 +0000
 Subject: [PATCH] xapi/qcow_tool_wrapper: Add note on using header information

--- a/SOURCES/0014-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
+++ b/SOURCES/0014-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
@@ -1,4 +1,4 @@
-From 1eff08ae05c491102c7a37769d65a1fd27d1d87c Mon Sep 17 00:00:00 2001
+From 8cd0aa79d9ba715ba43501e4bdea0baeabdb3924 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Fri, 6 Mar 2026 09:45:45 +0000
 Subject: [PATCH] xapi.conf: Switch to optimized data cluster format for VHD

--- a/SOURCES/0015-stream_vdi-Avoid-chunk-duplication-when-exporting-fr.patch
+++ b/SOURCES/0015-stream_vdi-Avoid-chunk-duplication-when-exporting-fr.patch
@@ -1,4 +1,4 @@
-From d34dd12b1f15ce342db2839bf01f834f91a6337a Mon Sep 17 00:00:00 2001
+From d9c0738cdd405f0dc9c02a2070cf2fd7862a0b8a Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 25 Mar 2026 13:38:41 +0000
 Subject: [PATCH] stream_vdi: Avoid chunk duplication when exporting from

--- a/SOURCES/0016-qcow_tool-wrapper-Call-qemu-img-instead-of-qcow-stre.patch
+++ b/SOURCES/0016-qcow_tool-wrapper-Call-qemu-img-instead-of-qcow-stre.patch
@@ -1,4 +1,4 @@
-From cc4235d94d41952816d3623d27622e6d3f93ca3c Mon Sep 17 00:00:00 2001
+From 6f419d56c4b42f8f842556a92593c4a9d9195352 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Fri, 27 Mar 2026 14:27:08 +0000
 Subject: [PATCH] qcow_tool-wrapper: Call qemu-img instead of qcow-stream-tool
@@ -277,14 +277,7 @@ index 0f473e4a4..0fae40f76 100755
      diff_nonzero_clusters = None
 -    if args.json_header:
 -        json_header = json.load(sys.stdin)
-+
-+    def parse_json_files(info_fd, map_fd):
-+        map_f = os.fdopen(map_fd)
-+        info_f = os.fdopen(info_fd)
-+        map_json = json.load(map_f)
-+        info_json = json.load(info_f)
-+
-         try:
+-        try:
 -            virtual_size = json_header['virtual_size']
 -            source_cluster_size = 2 ** json_header['cluster_bits']
 -            if source_cluster_size != args.cluster_size:
@@ -295,7 +288,14 @@ index 0f473e4a4..0fae40f76 100755
 -    if args.json_header_diff:
 -        f = os.fdopen(args.json_header_diff)
 -        json_header = json.load(f)
--        try:
++
++    def parse_json_files(info_fd, map_fd):
++        map_f = os.fdopen(map_fd)
++        info_f = os.fdopen(info_fd)
++        map_json = json.load(map_f)
++        info_json = json.load(info_f)
++
+         try:
 -            diff_virtual_size = json_header['virtual_size']
 -            if 2 ** json_header['cluster_bits'] == args.cluster_size:
 -                diff_nonzero_clusters = json_header['data_clusters']

--- a/SOURCES/0017-quicktests-Force-VDI-format-on-creation.patch
+++ b/SOURCES/0017-quicktests-Force-VDI-format-on-creation.patch
@@ -1,4 +1,4 @@
-From 9b93103bbcc42368a2b07410fea8270bc6b45210 Mon Sep 17 00:00:00 2001
+From 2302eca9fba517580171f6853a201b9b06fef83b Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Mon, 30 Mar 2026 15:23:42 +0000
 Subject: [PATCH] quicktests: Force VDI format on creation

--- a/SOURCES/0018-stream_vdi-Fix-last_chunk-calculation.patch
+++ b/SOURCES/0018-stream_vdi-Fix-last_chunk-calculation.patch
@@ -1,4 +1,4 @@
-From 89fcbf4a86a5d7f79250c6bf9c06f6b4131dae9d Mon Sep 17 00:00:00 2001
+From 8180301ae30a3605b0cadd1868f1728c57ef7590 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 8 Apr 2026 12:28:32 +0000
 Subject: [PATCH] stream_vdi: Fix last_chunk calculation

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.3
-Release: 1%{?xsrel}.7%{?dist}
+Release: 1%{?xsrel}.8%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -1516,6 +1516,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Tue Apr 14 2026 Sebastien Rodot <sebastien.rodot@vates.tech> - 26.1.3-1.8
+- Rework local patch [xcp-ng] open/close openflow port to open the port conditionally
+
 * Mon Apr 13 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.3-1.7
 - Apply new formatting to patches
 


### PR DESCRIPTION
Koji pre-build: https://koji.xcp-ng.org/taskinfo?taskID=102909
XCPNG-2470

The PR replace local patch `SOURCES/0004-xcp-ng-open-close-openflow-port.patch`.

Instead of open/close tcp:6653 unconditionnally, only open it if XO has not declared using xapi-plugin using `pool:other_config["xo:sdn-controller:of-method"]`.

It keep the current behaviour while XO isn't upgraded (if the other_config key is empty the port is opened/closed as now).