### PR TITLE
SOURCES: apply new formatting to patches

### DIFF
--- a/SOURCES/0001-xcp-ng-configure-xapi.conf-to-meet-our-needs.patch
+++ b/SOURCES/0001-xcp-ng-configure-xapi.conf-to-meet-our-needs.patch
@@ -1,4 +1,4 @@
-From 333abde9b71a4203c84889844da9e2cd89d19be2 Mon Sep 17 00:00:00 2001
+From 1cacced3c73ada32f36e4cde2ea37377ee55f693 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 11:05:15 +0200
 Subject: [PATCH] [xcp-ng] configure xapi.conf to meet our needs

--- a/SOURCES/0002-xcp-ng-renamed-xs-clipboardd-to-xcp-clipboardd.patch
+++ b/SOURCES/0002-xcp-ng-renamed-xs-clipboardd-to-xcp-clipboardd.patch
@@ -1,4 +1,4 @@
-From 4a4e15616a2ac1d671bee7709ced00dfa3845a02 Mon Sep 17 00:00:00 2001
+From d9bd5b20b36ac454ae71f4a80b5a7dfa6c2f3b27 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 11:11:46 +0200
 Subject: [PATCH] [xcp-ng] renamed xs-clipboardd to xcp-clipboardd

--- a/SOURCES/0003-xcp-ng-fix-IPv6-import.patch
+++ b/SOURCES/0003-xcp-ng-fix-IPv6-import.patch
@@ -1,4 +1,4 @@
-From 081e3da54536e198bc11d3b2682c4b94d252dc1d Mon Sep 17 00:00:00 2001
+From 06dd952d393c2bb6ada8aa4218b44c50deae271c Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 14:59:05 +0200
 Subject: [PATCH] [xcp-ng] fix IPv6 import
@@ -8,14 +8,14 @@ See: https://github.com/mirage/ocaml-cohttp/issues/997
 
 Signed-off-by: Guillaume <guillaume.thouvenin@vates.tech>
 ---
- ocaml/xapi/xapi_vm.ml | 18 +++++++++++++++++-
- 1 file changed, 17 insertions(+), 1 deletion(-)
+ ocaml/xapi/xapi_vm.ml | 28 +++++++++++++++++++++++++++-
+ 1 file changed, 27 insertions(+), 1 deletion(-)
 
 diff --git a/ocaml/xapi/xapi_vm.ml b/ocaml/xapi/xapi_vm.ml
-index 21b1704e8..ad6d21fc9 100644
+index 2d4595b6d..b2a61a8ec 100644
 --- a/ocaml/xapi/xapi_vm.ml
 +++ b/ocaml/xapi/xapi_vm.ml
-@@ -1527,7 +1527,23 @@ let rec import_inner n ~__context ~url ~sr ~full_restore ~force =
+@@ -1562,7 +1562,33 @@ let rec import_inner n ~__context ~url ~sr ~full_restore ~force =
              Cohttp.Request.Make (Cohttp_posix_io.Unbuffered_IO) in
            let module Response =
              Cohttp.Response.Make (Cohttp_posix_io.Unbuffered_IO) in
@@ -29,14 +29,24 @@ index 21b1704e8..ad6d21fc9 100644
 +          let headers = Cohttp.Header.init () in
 +          let headers =
 +            Cohttp.Header.add_unless_exists headers "host"
-+              (match Uri.scheme uri with
-+              | Some "httpunix" -> ""
++              ( match Uri.scheme uri with
++              | Some "httpunix" ->
++                  ""
 +              | _ -> (
-+                (maybe_wrap_IPv6_literal (Uri.host_with_default ~default:"localhost" uri))
++                  maybe_wrap_IPv6_literal
++                    (Uri.host_with_default ~default:"localhost" uri)
 +                  ^
-+                  match Uri.port uri with Some p -> ":" ^ string_of_int p | None -> ""))
++                  match Uri.port uri with
++                  | Some p ->
++                      ":" ^ string_of_int p
++                  | None ->
++                      ""
++                )
++              )
 +          in
-+          let request = Cohttp.Request.make ~meth:`GET ?headers:(Some headers) uri in
++          let request =
++            Cohttp.Request.make ~meth:`GET ?headers:(Some headers) uri
++          in
            let ic =
              {
                Cohttp_posix_io.Unbuffered_IO.header_buffer= None

--- a/SOURCES/0004-xcp-ng-open-close-openflow-port.patch
+++ b/SOURCES/0004-xcp-ng-open-close-openflow-port.patch
@@ -1,4 +1,4 @@
-From 74dd24126a2088c715fc364645beec7a0c040679 Mon Sep 17 00:00:00 2001
+From de49984976741b027edbed1fa2331ae51540d033 Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 17:06:38 +0200
 Subject: [PATCH] [xcp-ng] open/close openflow port

--- a/SOURCES/0005-xcp-ng-update-db-tunnel-protocol-from-other-config.patch
+++ b/SOURCES/0005-xcp-ng-update-db-tunnel-protocol-from-other-config.patch
@@ -1,4 +1,4 @@
-From 38764599f24f1e69ab918239d6765bf171cfb0a6 Mon Sep 17 00:00:00 2001
+From 3a436645ce4418878553e9384df5e5fa9e793b8d Mon Sep 17 00:00:00 2001
 From: Guillaume <guillaume.thouvenin@vates.tech>
 Date: Mon, 31 Mar 2025 17:10:15 +0200
 Subject: [PATCH] [xcp-ng] update db tunnel protocol from other config
@@ -26,44 +26,48 @@ transition for tunnels created before XCP-ng 8.2.
 
 Signed-off-by: Guillaume <guillaume.thouvenin@vates.tech>
 ---
- ocaml/xapi/xapi_db_upgrade.ml | 25 +++++++++++++++++++++++++
- 1 file changed, 25 insertions(+)
+ ocaml/xapi/xapi_db_upgrade.ml | 29 +++++++++++++++++++++++++++++
+ 1 file changed, 29 insertions(+)
 
 diff --git a/ocaml/xapi/xapi_db_upgrade.ml b/ocaml/xapi/xapi_db_upgrade.ml
-index e1f0eba63..1b1b2ac79 100644
+index aba1cf154..7fb4ee160 100644
 --- a/ocaml/xapi/xapi_db_upgrade.ml
 +++ b/ocaml/xapi/xapi_db_upgrade.ml
-@@ -106,6 +106,10 @@ let jura =
+@@ -106,6 +106,11 @@ let jura =
    , Datamodel_common.jura_release_schema_minor_vsn
    )
  
 +let quebec =
 +  ( Datamodel_common.quebec_release_schema_major_vsn
-+  , Datamodel_common.quebec_release_schema_minor_vsn )
++  , Datamodel_common.quebec_release_schema_minor_vsn
++  )
 +
  let yangtze =
    ( Datamodel_common.yangtze_release_schema_major_vsn
    , Datamodel_common.yangtze_release_schema_minor_vsn
-@@ -964,6 +968,26 @@ let upgrade_ca_fingerprints =
+@@ -965,6 +970,29 @@ let upgrade_ca_fingerprints =
        )
    }
  
 +let fill_tunnel_protocol =
 +  {
-+    description=
-+      "Fill up the new field protocol of a Tunnel"
++    description= "Fill up the new field protocol of a Tunnel"
 +  ; version= (fun x -> x <= quebec)
 +  ; fn=
 +      (fun ~__context ->
 +        Db.Tunnel.get_all ~__context
 +        |> List.iter (fun self ->
-+          let pif = Db.Tunnel.get_access_PIF ~__context ~self in
-+          let network = Db.PIF.get_network ~__context ~self:pif in
-+          let other_config = Db.Network.get_other_config ~__context ~self:network in
-+          let encapsulation = List.assoc_opt "xo:sdn-controller:encapsulation" other_config
-+            |> Option.value ~default:"gre" in
-+          let value = Record_util.tunnel_protocol_of_string encapsulation in
-+          Db.Tunnel.set_protocol ~__context ~self ~value
++            let pif = Db.Tunnel.get_access_PIF ~__context ~self in
++            let network = Db.PIF.get_network ~__context ~self:pif in
++            let other_config =
++              Db.Network.get_other_config ~__context ~self:network
++            in
++            let encapsulation =
++              List.assoc_opt "xo:sdn-controller:encapsulation" other_config
++              |> Option.value ~default:"gre"
++            in
++            let value = Record_util.tunnel_protocol_of_string encapsulation in
++            Db.Tunnel.set_protocol ~__context ~self ~value
 +        )
 +      )
 +  }
@@ -71,7 +75,7 @@ index e1f0eba63..1b1b2ac79 100644
  let rules =
    [
      upgrade_domain_type
-@@ -994,6 +1018,7 @@ let rules =
+@@ -995,6 +1023,7 @@ let rules =
    ; empty_pool_uefi_certificates
    ; upgrade_update_guidance
    ; upgrade_ca_fingerprints

--- a/SOURCES/0006-xcp-ng-do-not-change-rsyslog-configuration.patch
+++ b/SOURCES/0006-xcp-ng-do-not-change-rsyslog-configuration.patch
@@ -1,4 +1,4 @@
-From 2233e79691791db0f83849a219ccd0d5b534661e Mon Sep 17 00:00:00 2001
+From 9457b3799dff894706b0a2f111d6bfedb6c33505 Mon Sep 17 00:00:00 2001
 From: Pau Ruiz Safont <pau.safont@vates.tech>
 Date: Sat, 18 Oct 2025 09:21:18 +0100
 Subject: [PATCH] [xcp-ng] do not change rsyslog configuration

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.3
-Release: 1%{?xsrel}.6%{?dist}
+Release: 1%{?xsrel}.7%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -1516,6 +1516,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Mon Apr 13 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.3-1.7
+- Apply new formatting to patches
+
 * Tue Mar 24 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 26.1.3-1.6
 - When exporting QCOW2-backed VDIs, read headers of the whole snapshot chain
 - Fix duplicated chunks during VM export resulting in an invalid XVA


### PR DESCRIPTION
These changes come from the new version of the formatter, adopted
earlier this year, and were made by running

  git format-patch --no-numbered --no-signature v26.1.3..v26.1.3-8.3

On xcp-ng/xen-api