### PR TITLE
Backport more XSA-489 fixes, session refresh patches

### DIFF
--- a/SOURCES/0022-Refresh-remote-session-during-long-migrations.patch
+++ b/SOURCES/0022-Refresh-remote-session-during-long-migrations.patch
@@ -1,0 +1,65 @@
+From c4035d70bd8cdfc3a9f53a796e79c3b4985f4b89 Mon Sep 17 00:00:00 2001
+From: Guillaume <guillaume.thouvenin@vates.tech>
+Date: Wed, 28 Jan 2026 13:43:02 +0100
+Subject: [PATCH] Refresh remote session during long migrations
+
+Long VM migrations can exceed the default SM session timeout (24h), causing the
+destination host to fail when using an expired session. This is especially
+problematic for large VDI copies.
+
+This patch ensures migrations do not fail due to session expiration by
+refreshing the remote session periodically while the data copy is in progress.
+
+(cherry picked from commit e76c03910)
+
+Signed-off-by: Guillaume <guillaume.thouvenin@vates.tech>
+---
+ ocaml/xapi/xapi_vm_migrate.ml | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/ocaml/xapi/xapi_vm_migrate.ml b/ocaml/xapi/xapi_vm_migrate.ml
+index f39f45d13..d6405f149 100644
+--- a/ocaml/xapi/xapi_vm_migrate.ml
++++ b/ocaml/xapi/xapi_vm_migrate.ml
+@@ -1443,7 +1443,41 @@ let migrate_send' ~__context ~vm ~dest ~live:_ ~vdi_map ~vif_map ~vgpu_map
+       List.fold_left (fun acc vconf -> Int64.add acc vconf.size) 0L all_vdis
+     in
+     let so_far = ref 0L in
++    let keep_refreshing = Atomic.make true in
++    let _ =
++      Thread.create
++        (fun () ->
++          let session_id = remote.session in
++          let refresh_session =
++            Xapi_session.consider_touching_session remote.rpc session_id
++          in
++          let threshold =
++            Ptime.Span.to_float_s !Xapi_globs.threshold_last_active
++            |> int_of_float
++          in
++          let just_refreshed () =
++            Clock.Timer.start ~duration:Mtime.Span.((threshold + 5) * s)
++          in
++          let next_refresh = ref (just_refreshed ()) in
++          debug "%s: starting refreshing thread" __FUNCTION__ ;
++          while Atomic.get keep_refreshing do
++            if Clock.Timer.has_expired !next_refresh then (
++              refresh_session () ;
++              debug "%s: refresh_session called" __FUNCTION__ ;
++              next_refresh := just_refreshed ()
++            ) ;
++            Thread.delay 10.
++          done ;
++          debug "%s: stopping refreshing thread" __FUNCTION__
++        )
++        ()
++    in
+     let new_vm =
++      Fun.protect ~finally:(fun () ->
++          debug "%s: setting keep_refreshing to false" __FUNCTION__ ;
++          Atomic.set keep_refreshing false
++      )
++      @@ fun () ->
+       with_many
+         (vdi_copy_fun __context dbg vdi_map remote is_intra_pool remote_vdis
+            so_far total_size copy

--- a/SOURCES/0023-xapi_vm-Implement-RBAC-checking-for-keys-in-set_othe.patch
+++ b/SOURCES/0023-xapi_vm-Implement-RBAC-checking-for-keys-in-set_othe.patch
@@ -1,0 +1,570 @@
+From e2abec812b4517f0d029c43c24974bc1c566e72d Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 27 Apr 2026 09:16:20 +0000
+Subject: [PATCH] xapi_vm: Implement RBAC checking for keys in set_other_config
+
+map_keys_roles parameter was RBAC checked for
+{add_to,remove_from}_other_config, but set_other_config allowed
+circumventing this check.
+
+Since VM is the only object that has a key ("pci") in other_config
+with the privilege level required for modification higher than that of the
+other_config field generally, this meant that vm-admin could not modify the
+"pci" key in other_config through add_to_other_config, but could circumvent the
+check with set_other_config.
+
+Implement a checker for VM.other_config setters based on Task's manual RBAC
+checker (introduced in a3f2c6e8f4edc089913b3f0208b0140ca0fef0c5)
+
+This is part of XSA-489 / CVE-2026-23562
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+(cherry picked from commit 2469636281681d4589c4b580d2d9e56c4f5ff497)
+---
+ ocaml/idl/datamodel_vm.ml        |  58 +++++++++-
+ ocaml/xapi/helpers.ml            | 182 ++++++++++++++++++++++++++++++
+ ocaml/xapi/message_forwarding.ml |  14 +++
+ ocaml/xapi/xapi_task.ml          | 187 +------------------------------
+ ocaml/xapi/xapi_vm.ml            |  12 ++
+ ocaml/xapi/xapi_vm.mli           |   9 ++
+ 6 files changed, 280 insertions(+), 182 deletions(-)
+
+diff --git a/ocaml/idl/datamodel_vm.ml b/ocaml/idl/datamodel_vm.ml
+index 17178314a..419f82662 100644
+--- a/ocaml/idl/datamodel_vm.ml
++++ b/ocaml/idl/datamodel_vm.ml
+@@ -2383,6 +2383,59 @@ let sysprep =
+        as part of a reboot."
+     ~allowed_roles:_R_VM_ADMIN ()
+ 
++module Other_config = struct
++  let protected_keys =
++    [
++      ("pci", _R_POOL_ADMIN)
++    ; ("folder", _R_VM_OP)
++    ; ("XenCenter.CustomFields.*", _R_VM_OP)
++    ]
++
++  let call =
++    call
++      ~lifecycle:[(Published, rel_rio, "additional configuration")]
++      ~allowed_roles:_R_VM_ADMIN
++
++  let add_to_other_config =
++    call ~name:"add_to_other_config"
++      ~doc:
++        "Add the given key-value pair to the other_config field of the given \
++         VM."
++      ~params:
++        [
++          (Ref _vm, "self", "reference to object")
++        ; (String, "key", "Key to add")
++        ; (String, "value", "Value to add")
++        ]
++      ~map_keys_roles:protected_keys ~flags:[`Session] ()
++
++  let remove_from_other_config =
++    call ~name:"remove_from_other_config"
++      ~doc:
++        "Remove the given key and its corresponding value from the \
++         other_config field of the given VM. If the key is not in that Map, \
++         then do nothing."
++      ~params:
++        [
++          (Ref _vm, "self", "reference to object")
++        ; (String, "key", "Key of entry to remove")
++        ]
++      ~map_keys_roles:protected_keys ~flags:[`Session] ()
++
++  (* map_keys_roles can't be cited here, since they're only implemented for
++   {add_to,remove_from}_other_config, RBAC handling is done in a manual
++   implementation. *)
++  let set_other_config =
++    call ~name:"set_other_config"
++      ~doc:"Set the other_config field of the given VM."
++      ~params:
++        [
++          (Ref _vm, "self", "reference to object")
++        ; (Map (String, String), "value", "New value to set")
++        ]
++      ~flags:[`Session] ()
++end
++
+ let vm_uefi_mode =
+   Enum
+     ( "vm_uefi_mode"
+@@ -2586,6 +2639,9 @@ let t =
+       ; add_to_blocked_operations
+       ; remove_from_blocked_operations
+       ; sysprep
++      ; Other_config.add_to_other_config
++      ; Other_config.remove_from_other_config
++      ; Other_config.set_other_config
+       ]
+     ~contents:
+       ([
+@@ -2725,7 +2781,7 @@ let t =
+               ; (Deprecated, rel_boston, "Field was never used")
+               ]
+             "PCI_bus" "PCI bus path for pass-through devices"
+-        ; field
++        ; field ~qualifier:StaticRO
+             ~lifecycle:[(Published, rel_rio, "additional configuration")]
+             ~ty:(Map (String, String))
+             "other_config" "additional configuration"
+diff --git a/ocaml/xapi/helpers.ml b/ocaml/xapi/helpers.ml
+index e791dc72c..3a3008c24 100644
+--- a/ocaml/xapi/helpers.ml
++++ b/ocaml/xapi/helpers.ml
+@@ -2466,3 +2466,185 @@ module AuthenticationCache = struct
+           None
+   end
+ end
++
++(* Simple trie data structure that performs a favoured lookup to
++   implement a simple form of wildcard key matching. The trie is not
++   pruned during (or after) construction. *)
++module MatchTrie = struct
++  type 'a node = {arrows: (string, 'a node) Hashtbl.t; mutable value: 'a option}
++
++  let create_node () =
++    let arrows = Hashtbl.create 16 in
++    let value = None in
++    {arrows; value}
++
++  let create = create_node
++
++  let insert root ~key ~value =
++    let parts = String.split_on_char '.' key in
++    let rec extend focused = function
++      | part :: parts ->
++          let next =
++            match Hashtbl.find_opt focused.arrows part with
++            | Some node ->
++                node
++            | _ ->
++                let next = create_node () in
++                Hashtbl.replace focused.arrows part next ;
++                next
++          in
++          extend next parts
++      | [] ->
++          focused
++    in
++    let final = extend root parts in
++    final.value <- Some value
++
++  let find root ~key =
++    let parts = String.split_on_char '.' key in
++    let rec find focused = function
++      | part :: parts -> (
++        (* Wildcard edges override other edges. *)
++        match Hashtbl.find_opt focused.arrows "*" with
++        | Some _ as sink ->
++            sink
++        | _ -> (
++          match Hashtbl.find_opt focused.arrows part with
++          | Some next ->
++              (find [@tailcall]) next parts
++          | _ ->
++              None
++        )
++      )
++      | _ ->
++          Some focused
++    in
++    match find root parts with Some node -> node.value | _ -> None
++end
++
++(* Given an input key, compare against the protected keys of the
++   task.other_config field. If a protected key matches, return it.
++
++   For example, if the datamodel specifies "foo.bar.*" as a protected
++   key, then: match_protected_key ~key:"foo.bar.baz" = Some "foo.bar.*".
++
++   It must return the protected key as that is what key-related RBAC
++   entries are defined in terms of.
++*)
++let match_protected_key objname fieldname =
++  (* Attain the listing of protected keys from the datamodel at module
++     initialisation. Usually, this list is passed to Rbac.check by
++     handlers inside the auto-generated server.ml file. *)
++  let protected_keys =
++    let api = Datamodel.all_api in
++    let field = Dm_api.get_field_by_name api ~objname ~fieldname in
++    List.map fst field.field_map_keys_roles
++  in
++  (* Define the lookup function in terms of a simple trie data
++     structure - which is flexible to account for overlapping paths and
++     presence of wildcards. *)
++  let trie =
++    let root = MatchTrie.create () in
++    let add key = MatchTrie.insert root ~key ~value:key in
++    List.iter add protected_keys ;
++    root
++  in
++  MatchTrie.find trie
++
++(* The behaviour of this function, with respect to RBAC checking, must
++   match serial "remove_from" and "add_to" operations (for only the keys
++   that are changing).
++
++   There is normally no key-related RBAC checking for
++   "set_X" (e.g. set_other_config) because the required writer role for the
++   entire field is usually higher than the role(s) required for
++   individually-protected keys.
++
++   Task and VM's "set_other_config" are special cases where lower-privileged
++   sessions must be able to manipulate a subset of entries (those not
++   protected by a more privileged role).
++*)
++let set_map_with_rbac ~__context ~self ~value ~get_fn ~set_fn ~match_protected
++    ~object_name ~field_name =
++  let match_protected = match_protected field_name in
++  let module S = Set.Make (String) in
++  let create_lookup kvs =
++    let table = List.to_seq kvs |> Hashtbl.of_seq in
++    Hashtbl.find_opt table
++  in
++  let old_value = get_fn ~__context ~self in
++  let lookup_old, lookup_new = (create_lookup old_value, create_lookup value) in
++  let keys_before, keys_after =
++    let keys = List.map fst in
++    let before = keys old_value in
++    let after = keys value in
++    S.(of_list before, of_list after)
++  in
++  let keys_removed =
++    (* Keys no longer appearing in the map. The user must have the
++       "remove_from" role for each of the protected keys in the set. *)
++    S.diff keys_before keys_after
++  in
++  let keys_unchanged =
++    (* Keys that persist across the update. If any key in this set is
++       protected AND the value mapped to by the key would be changed by
++       the update, the session must have the "add_to" role. *)
++    let updated = S.inter keys_before keys_after in
++    let is_entry_unchanged key =
++      let is_same =
++        let ( let* ) = Option.bind in
++        let* old_value = lookup_old key in
++        let* new_value = lookup_new key in
++        Some (old_value = new_value)
++      in
++      Option.value ~default:false is_same
++    in
++    (* Filter out the unchanged entries, as you don't need any
++       extra privileges to maintain an entry that's already there. *)
++    S.filter is_entry_unchanged updated
++  in
++  let keys_added =
++    (* Treat all keys as new, unless they're referring to entries that
++       are unchanged across the update. *)
++    S.diff keys_after keys_unchanged
++  in
++  let permissions =
++    (* Map each of the added and removed keys to protected keys, if
++       such a key exists. *)
++    let filter keys =
++      S.filter_map (fun key -> match_protected ~key) keys |> S.elements
++    in
++    let added = filter keys_added in
++    let removed = filter keys_removed in
++    let format operation key =
++      (* All the permissions are stored in lowercase. *)
++      let key = String.lowercase_ascii key in
++      Printf.sprintf "%s.%s_%s/key:%s" object_name operation field_name key
++    in
++    (* The required permissions are defined in terms of those
++       generated for "add_to" and "remove_from" (both implemented
++       above). They can be defined as custom AND use RBAC checking within
++       server.ml because their operation is purely destructive, so it's
++       sufficient to guard the entire action with Rbac.check. *)
++    let added_perms = List.map (format "add_to") added in
++    let removed_perms = List.map (format "remove_from") removed in
++    added_perms @ removed_perms
++  in
++  (* Find the first disallowed permission, indicating that we cannot
++     perform the action. *)
++  let session_id = Context.get_session_id __context in
++  match
++    Rbac.find_first_disallowed_permission ~__context ~session_id ~permissions
++  with
++  | None ->
++      (* No disallowed permission, perform the update. *)
++      set_fn ~__context ~self ~value
++  | Some disallowed ->
++      (* Report it as an RBAC error. *)
++      let action = Printf.sprintf "%s.set_%s" object_name field_name in
++      let extra_msg = "" in
++      let extra_dmsg = "" in
++      raise
++        (Rbac.disallowed_permission_exn ~extra_dmsg ~extra_msg ~__context
++           ~permission:disallowed ~action
++        )
+diff --git a/ocaml/xapi/message_forwarding.ml b/ocaml/xapi/message_forwarding.ml
+index 83786bd8a..53245fbc0 100644
+--- a/ocaml/xapi/message_forwarding.ml
++++ b/ocaml/xapi/message_forwarding.ml
+@@ -3167,6 +3167,20 @@ functor
+           ~policy (fun () ->
+             forward_vm_op ~local_fn ~__context ~vm:self ~remote_fn
+         )
++
++      let add_to_other_config ~__context ~self ~key ~value =
++        info "VM.add_to_other_config: self = '%s', key = '%s'"
++          (vm_uuid ~__context self) key ;
++        Local.VM.add_to_other_config ~__context ~self ~key ~value
++
++      let remove_from_other_config ~__context ~self ~key =
++        info "VM.remove_from_other_config: self = '%s', key = '%s'"
++          (vm_uuid ~__context self) key ;
++        Local.VM.remove_from_other_config ~__context ~self ~key
++
++      let set_other_config ~__context ~self ~value =
++        info "VM.set_other_config: self = '%s'" (vm_uuid ~__context self) ;
++        Local.VM.set_other_config ~__context ~self ~value
+     end
+ 
+     module VM_metrics = struct end
+diff --git a/ocaml/xapi/xapi_task.ml b/ocaml/xapi/xapi_task.ml
+index 8c6ebf00a..93c91c9af 100644
+--- a/ocaml/xapi/xapi_task.ml
++++ b/ocaml/xapi/xapi_task.ml
+@@ -89,92 +89,8 @@ let set_resident_on ~__context ~self ~value =
+   TaskHelper.assert_op_valid ~__context self ;
+   Db.Task.set_resident_on ~__context ~self ~value
+ 
+-(* Simple trie data structure that performs a favoured lookup to
+-   implement a simple form of wildcard key matching. The trie is not
+-   pruned during (or after) construction. *)
+-module MatchTrie = struct
+-  type 'a node = {arrows: (string, 'a node) Hashtbl.t; mutable value: 'a option}
+-
+-  let create_node () =
+-    let arrows = Hashtbl.create 16 in
+-    let value = None in
+-    {arrows; value}
+-
+-  let create = create_node
+-
+-  let insert root ~key ~value =
+-    let parts = String.split_on_char '.' key in
+-    let rec extend focused = function
+-      | part :: parts ->
+-          let next =
+-            match Hashtbl.find_opt focused.arrows part with
+-            | Some node ->
+-                node
+-            | _ ->
+-                let next = create_node () in
+-                Hashtbl.replace focused.arrows part next ;
+-                next
+-          in
+-          extend next parts
+-      | [] ->
+-          focused
+-    in
+-    let final = extend root parts in
+-    final.value <- Some value
+-
+-  let find root ~key =
+-    let parts = String.split_on_char '.' key in
+-    let rec find focused = function
+-      | part :: parts -> (
+-        (* Wildcard edges override other edges. *)
+-        match Hashtbl.find_opt focused.arrows "*" with
+-        | Some _ as sink ->
+-            sink
+-        | _ -> (
+-          match Hashtbl.find_opt focused.arrows part with
+-          | Some next ->
+-              (find [@tailcall]) next parts
+-          | _ ->
+-              None
+-        )
+-      )
+-      | _ ->
+-          Some focused
+-    in
+-    match find root parts with Some node -> node.value | _ -> None
+-end
+-
+-(* Given an input key, compare against the protected keys of the
+-   task.other_config field. If a protected key matches, return it.
+-
+-   For example, if the datamodel specifies "foo.bar.*" as a protected
+-   key, then: match_protected_key ~key:"foo.bar.baz" = Some "foo.bar.*".
+-
+-   It must return the protected key as that is what key-related RBAC
+-   entries are defined in terms of.
+-*)
+-let match_protected_key =
+-  (* Attain the listing of protected keys from the datamodel at module
+-     initialisation. Usually, this list is passed to Rbac.check by
+-     handlers inside the auto-generated server.ml file. *)
+-  let protected_keys =
+-    let api = Datamodel.all_api in
+-    let field =
+-      Dm_api.get_field_by_name api ~objname:"task" ~fieldname:"other_config"
+-    in
+-    List.map fst field.field_map_keys_roles
+-  in
+-  (* Define the lookup function in terms of a simple trie data
+-     structure - which is flexible to account for overlapping paths and
+-     presence of wildcards. *)
+-  let trie =
+-    let root = MatchTrie.create () in
+-    let add key = MatchTrie.insert root ~key ~value:key in
+-    List.iter add protected_keys ;
+-    root
+-  in
+-  MatchTrie.find trie
+-
++(* restricts all *_other_config calls to only the task objects that
++   sessions created. *)
+ let assert_can_modify_other_config ~__context ~task =
+   TaskHelper.assert_op_valid ~__context task
+ 
+@@ -186,100 +102,9 @@ let remove_from_other_config ~__context ~self ~key =
+   assert_can_modify_other_config ~__context ~task:self ;
+   Db.Task.remove_from_other_config ~__context ~self ~key
+ 
+-(* The behaviour of this function, with respect to RBAC checking, must
+-   match serial "remove_from" and "add_to" operations (for only the keys
+-   that are changing).
+-
+-   There is normally no key-related RBAC checking for
+-   "set_other_config" because the required writer role for the entire
+-   field is usually higher than the role(s) required for
+-   individually-protected keys.
+-
+-   Task's "set_other_config" is a special case where read-only
+-   sessions must be able to manipulate a subset of entries (those not
+-   protected by a more privileged role), along with this capability
+-   being restricted to only the task objects that they created.
+-*)
+ let set_other_config ~__context ~self ~value =
+-  let module S = Set.Make (String) in
+   assert_can_modify_other_config ~__context ~task:self ;
+-  let create_lookup kvs =
+-    let table = List.to_seq kvs |> Hashtbl.of_seq in
+-    Hashtbl.find_opt table
+-  in
+-  let old_value = Db.Task.get_other_config ~__context ~self in
+-  let lookup_old, lookup_new = (create_lookup old_value, create_lookup value) in
+-  let keys_before, keys_after =
+-    let keys = List.map fst in
+-    let before = keys old_value in
+-    let after = keys value in
+-    S.(of_list before, of_list after)
+-  in
+-  let keys_removed =
+-    (* Keys no longer appearing in the map. The user must have the
+-       "remove_from" role for each of the protected keys in the set. *)
+-    S.diff keys_before keys_after
+-  in
+-  let keys_unchanged =
+-    (* Keys that persist across the update. If any key in this set is
+-       protected AND the value mapped to by the key would be changed by
+-       the update, the session must have the "add_to" role. *)
+-    let updated = S.inter keys_before keys_after in
+-    let is_entry_unchanged key =
+-      let is_same =
+-        let ( let* ) = Option.bind in
+-        let* old_value = lookup_old key in
+-        let* new_value = lookup_new key in
+-        Some (old_value = new_value)
+-      in
+-      Option.value ~default:false is_same
+-    in
+-    (* Filter out the unchanged entries, as you don't need any
+-       extra privileges to maintain an entry that's already there. *)
+-    S.filter is_entry_unchanged updated
+-  in
+-  let keys_added =
+-    (* Treat all keys as new, unless they're referring to entries that
+-       are unchanged across the update. *)
+-    S.diff keys_after keys_unchanged
+-  in
+-  let permissions =
+-    (* Map each of the added and removed keys to protected keys, if
+-       such a key exists. *)
+-    let filter keys =
+-      S.filter_map (fun key -> match_protected_key ~key) keys |> S.elements
+-    in
+-    let added = filter keys_added in
+-    let removed = filter keys_removed in
+-    let format operation key =
+-      (* All the permissions are stored in lowercase. *)
+-      let key = String.lowercase_ascii key in
+-      Printf.sprintf "task.%s_other_config/key:%s" operation key
+-    in
+-    (* The required permissions are defined in terms of those
+-       generated for "add_to" and "remove_from" (both implemented
+-       above). They can be defined as custom AND use RBAC checking within
+-       server.ml because their operation is purely destructive, so it's
+-       sufficient to guard the entire action with Rbac.check. *)
+-    let added_perms = List.map (format "add_to") added in
+-    let removed_perms = List.map (format "remove_from") removed in
+-    added_perms @ removed_perms
+-  in
+-  (* Find the first disallowed permission, indicating that we cannot
+-     perform the action. *)
+-  let session_id = Context.get_session_id __context in
+-  match
+-    Rbac.find_first_disallowed_permission ~__context ~session_id ~permissions
+-  with
+-  | None ->
+-      (* No disallowed permission, perform the update. *)
+-      Db.Task.set_other_config ~__context ~self ~value
+-  | Some disallowed ->
+-      (* Report it as an RBAC error. *)
+-      let action = "task.set_other_config" in
+-      let extra_msg = "" in
+-      let extra_dmsg = "" in
+-      raise
+-        (Rbac.disallowed_permission_exn ~extra_dmsg ~extra_msg ~__context
+-           ~permission:disallowed ~action
+-        )
++  let match_protected = Helpers.match_protected_key "task" in
++  Helpers.set_map_with_rbac ~__context ~self ~value
++    ~get_fn:Db.Task.get_other_config ~set_fn:Db.Task.set_other_config
++    ~match_protected ~object_name:"task" ~field_name:"other_config"
+diff --git a/ocaml/xapi/xapi_vm.ml b/ocaml/xapi/xapi_vm.ml
+index b2a61a8ec..9c1c57872 100644
+--- a/ocaml/xapi/xapi_vm.ml
++++ b/ocaml/xapi/xapi_vm.ml
+@@ -1806,3 +1806,15 @@ let sysprep ~__context ~self ~unattend ~timeout =
+       raise Api_errors.(Server_error (sysprep, [uuid; msg]))
+   | exception e ->
+       raise e
++
++let add_to_other_config ~__context ~self ~key ~value =
++  Db.VM.add_to_other_config ~__context ~self ~key ~value
++
++let remove_from_other_config ~__context ~self ~key =
++  Db.VM.remove_from_other_config ~__context ~self ~key
++
++let set_other_config ~__context ~self ~value =
++  let match_protected = Helpers.match_protected_key "VM" in
++  Helpers.set_map_with_rbac ~__context ~self ~value
++    ~get_fn:Db.VM.get_other_config ~set_fn:Db.VM.set_other_config
++    ~match_protected ~object_name:"vm" ~field_name:"other_config"
+diff --git a/ocaml/xapi/xapi_vm.mli b/ocaml/xapi/xapi_vm.mli
+index b3f07d38a..af682a834 100644
+--- a/ocaml/xapi/xapi_vm.mli
++++ b/ocaml/xapi/xapi_vm.mli
+@@ -457,3 +457,12 @@ val sysprep :
+   -> unattend:SecretString.t
+   -> timeout:float
+   -> unit
++
++val add_to_other_config :
++  __context:Context.t -> self:API.ref_VM -> key:string -> value:string -> unit
++
++val remove_from_other_config :
++  __context:Context.t -> self:API.ref_VM -> key:string -> unit
++
++val set_other_config :
++  __context:Context.t -> self:API.ref_VM -> value:(string * string) list -> unit

--- a/SOURCES/0024-xapi_vm-Implement-per-key-RBAC-checking-for-VM.platf.patch
+++ b/SOURCES/0024-xapi_vm-Implement-per-key-RBAC-checking-for-VM.platf.patch
@@ -1,0 +1,198 @@
+From 6c9c629a9e3d48d6da90a92476152d35bb32b652 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 27 Apr 2026 13:18:57 +0000
+Subject: [PATCH] xapi_vm: Implement per-key RBAC checking for VM.platform
+
+platform:hvm_serial and other_config:hvm_serial are both keys that allow host
+filesystem write. Limit these to be modifiable only by pool-admin.
+
+Implement set_platform with Helpers.set_map_with_rbac, like for
+set_other_config.
+
+This is part of XSA-489 / CVE-2026-42486
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+(cherry picked from commit e3cf6793be65db0563249155dfa24f4bc11cc540)
+---
+ ocaml/idl/datamodel_vm.ml        | 55 ++++++++++++++++++++++++++++++--
+ ocaml/xapi/helpers.ml            |  6 ++--
+ ocaml/xapi/message_forwarding.ml | 14 ++++++++
+ ocaml/xapi/xapi_vm.ml            | 12 +++++++
+ ocaml/xapi/xapi_vm.mli           |  9 ++++++
+ 5 files changed, 91 insertions(+), 5 deletions(-)
+
+diff --git a/ocaml/idl/datamodel_vm.ml b/ocaml/idl/datamodel_vm.ml
+index 419f82662..d556ef812 100644
+--- a/ocaml/idl/datamodel_vm.ml
++++ b/ocaml/idl/datamodel_vm.ml
+@@ -2386,7 +2386,8 @@ let sysprep =
+ module Other_config = struct
+   let protected_keys =
+     [
+-      ("pci", _R_POOL_ADMIN)
++      ("hvm_serial", _R_POOL_ADMIN)
++    ; ("pci", _R_POOL_ADMIN)
+     ; ("folder", _R_VM_OP)
+     ; ("XenCenter.CustomFields.*", _R_VM_OP)
+     ]
+@@ -2436,6 +2437,51 @@ module Other_config = struct
+       ~flags:[`Session] ()
+ end
+ 
++module Platform = struct
++  let protected_keys = [("hvm_serial", _R_POOL_ADMIN)]
++
++  let call =
++    call
++      ~lifecycle:[(Published, rel_rio, "platform-specific configuration")]
++      ~allowed_roles:_R_VM_ADMIN
++
++  let add_to_platform =
++    call ~name:"add_to_platform"
++      ~doc:"Add the given key-value pair to the platform field of the given VM."
++      ~params:
++        [
++          (Ref _vm, "self", "reference to object")
++        ; (String, "key", "Key to add")
++        ; (String, "value", "Value to add")
++        ]
++      ~map_keys_roles:protected_keys ~flags:[`Session] ()
++
++  let remove_from_platform =
++    call ~name:"remove_from_platform"
++      ~doc:
++        "Remove the given key and its corresponding value from the platform \
++         field of the given VM. If the key is not in that Map, then do \
++         nothing."
++      ~params:
++        [
++          (Ref _vm, "self", "reference to object")
++        ; (String, "key", "Key of entry to remove")
++        ]
++      ~map_keys_roles:protected_keys ~flags:[`Session] ()
++
++  (* map_keys_roles can't be cited here, since they're only implemented for
++   {add_to,remove_from}_platform, RBAC handling is done in a manual
++   implementation. *)
++  let set_platform =
++    call ~name:"set_platform" ~doc:"Set the platform field of the given VM."
++      ~params:
++        [
++          (Ref _vm, "self", "reference to object")
++        ; (Map (String, String), "value", "New value to set")
++        ]
++      ~flags:[`Session] ()
++end
++
+ let vm_uefi_mode =
+   Enum
+     ( "vm_uefi_mode"
+@@ -2642,6 +2688,9 @@ let t =
+       ; Other_config.add_to_other_config
+       ; Other_config.remove_from_other_config
+       ; Other_config.set_other_config
++      ; Platform.add_to_platform
++      ; Platform.remove_from_platform
++      ; Platform.set_platform
+       ]
+     ~contents:
+       ([
+@@ -2770,9 +2819,10 @@ let t =
+             ~qualifier:DynamicRO ~ty:(Set (Ref _vtpm)) "VTPMs" "virtual TPMs"
+         ; namespace ~name:"PV" ~contents:pv ()
+         ; namespace ~name:"HVM" ~contents:hvm ()
+-        ; field
++        ; field ~qualifier:StaticRO
+             ~ty:(Map (String, String))
+             ~lifecycle:[(Published, rel_rio, "platform-specific configuration")]
++            ~map_keys_roles:[("hvm_serial", _R_POOL_ADMIN)]
+             "platform" "platform-specific configuration"
+         ; field
+             ~lifecycle:
+@@ -2788,6 +2838,7 @@ let t =
+             ~map_keys_roles:
+               [
+                 ("pci", _R_POOL_ADMIN)
++              ; ("hvm_serial", _R_POOL_ADMIN)
+               ; ("folder", _R_VM_OP)
+               ; ("XenCenter.CustomFields.*", _R_VM_OP)
+               ]
+diff --git a/ocaml/xapi/helpers.ml b/ocaml/xapi/helpers.ml
+index 3a3008c24..832a4c0ca 100644
+--- a/ocaml/xapi/helpers.ml
++++ b/ocaml/xapi/helpers.ml
+@@ -2560,9 +2560,9 @@ let match_protected_key objname fieldname =
+    entire field is usually higher than the role(s) required for
+    individually-protected keys.
+ 
+-   Task and VM's "set_other_config" are special cases where lower-privileged
+-   sessions must be able to manipulate a subset of entries (those not
+-   protected by a more privileged role).
++   {Task,VM}.set_other_config and VM.set_platform are special cases where
++   lower-privileged sessions must be able to manipulate a subset of entries
++   (those not protected by a more privileged role).
+ *)
+ let set_map_with_rbac ~__context ~self ~value ~get_fn ~set_fn ~match_protected
+     ~object_name ~field_name =
+diff --git a/ocaml/xapi/message_forwarding.ml b/ocaml/xapi/message_forwarding.ml
+index 53245fbc0..d6d64a4d8 100644
+--- a/ocaml/xapi/message_forwarding.ml
++++ b/ocaml/xapi/message_forwarding.ml
+@@ -3181,6 +3181,20 @@ functor
+       let set_other_config ~__context ~self ~value =
+         info "VM.set_other_config: self = '%s'" (vm_uuid ~__context self) ;
+         Local.VM.set_other_config ~__context ~self ~value
++
++      let add_to_platform ~__context ~self ~key ~value =
++        info "VM.add_to_platform: self = '%s', key = '%s'"
++          (vm_uuid ~__context self) key ;
++        Local.VM.add_to_platform ~__context ~self ~key ~value
++
++      let remove_from_platform ~__context ~self ~key =
++        info "VM.remove_from_platform: self = '%s', key = '%s'"
++          (vm_uuid ~__context self) key ;
++        Local.VM.remove_from_platform ~__context ~self ~key
++
++      let set_platform ~__context ~self ~value =
++        info "VM.set_platform: self = '%s'" (vm_uuid ~__context self) ;
++        Local.VM.set_platform ~__context ~self ~value
+     end
+ 
+     module VM_metrics = struct end
+diff --git a/ocaml/xapi/xapi_vm.ml b/ocaml/xapi/xapi_vm.ml
+index 9c1c57872..1f4845b44 100644
+--- a/ocaml/xapi/xapi_vm.ml
++++ b/ocaml/xapi/xapi_vm.ml
+@@ -1818,3 +1818,15 @@ let set_other_config ~__context ~self ~value =
+   Helpers.set_map_with_rbac ~__context ~self ~value
+     ~get_fn:Db.VM.get_other_config ~set_fn:Db.VM.set_other_config
+     ~match_protected ~object_name:"vm" ~field_name:"other_config"
++
++let add_to_platform ~__context ~self ~key ~value =
++  Db.VM.add_to_platform ~__context ~self ~key ~value
++
++let remove_from_platform ~__context ~self ~key =
++  Db.VM.remove_from_platform ~__context ~self ~key
++
++let set_platform ~__context ~self ~value =
++  let match_protected = Helpers.match_protected_key "VM" in
++  Helpers.set_map_with_rbac ~__context ~self ~value ~get_fn:Db.VM.get_platform
++    ~set_fn:Db.VM.set_platform ~match_protected ~object_name:"vm"
++    ~field_name:"platform"
+diff --git a/ocaml/xapi/xapi_vm.mli b/ocaml/xapi/xapi_vm.mli
+index af682a834..5c3392e4e 100644
+--- a/ocaml/xapi/xapi_vm.mli
++++ b/ocaml/xapi/xapi_vm.mli
+@@ -466,3 +466,12 @@ val remove_from_other_config :
+ 
+ val set_other_config :
+   __context:Context.t -> self:API.ref_VM -> value:(string * string) list -> unit
++
++val add_to_platform :
++  __context:Context.t -> self:API.ref_VM -> key:string -> value:string -> unit
++
++val remove_from_platform :
++  __context:Context.t -> self:API.ref_VM -> key:string -> unit
++
++val set_platform :
++  __context:Context.t -> self:API.ref_VM -> value:(string * string) list -> unit

--- a/SOURCES/0025-idl-Update-the-schematest-hash.patch
+++ b/SOURCES/0025-idl-Update-the-schematest-hash.patch
@@ -1,0 +1,34 @@
+From 3e22e16eda66e2ef38bd4f75abad60b51f8771be Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 27 Apr 2026 13:22:52 +0000
+Subject: [PATCH] idl: Update the schematest hash
+
+The only difference in the schematest comes from changing the type of the
+other_config and platform fields from RW to StaticRO, which is necessary to
+provide custom implementations of setters.
+
+With a modified schematest, the diff is:
+
+    <     "qualifier": "RW",
+    ---
+    >     "qualifier": "StaticRO",
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+(similar to commit 47d8a6f9ead39f01fe0af353dae60a11b8305591)
+---
+ ocaml/idl/schematest.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ocaml/idl/schematest.ml b/ocaml/idl/schematest.ml
+index a90bf8687..4af7d368d 100644
+--- a/ocaml/idl/schematest.ml
++++ b/ocaml/idl/schematest.ml
+@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
+ (* BEWARE: if this changes, check that schema has been bumped accordingly in
+    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
+ 
+-let last_known_schema_hash = "a01358e3ff5f42d5aee162e995d2ec05"
++let last_known_schema_hash = "88b40556fd6a45af918900ff6d8079c5"
+ 
+ let current_schema_hash : string =
+   let open Datamodel_types in

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.3
-Release: 1%{?xsrel}.9%{?dist}
+Release: 1%{?xsrel}.10%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -117,9 +117,18 @@ Patch1016: 0016-qcow_tool-wrapper-Call-qemu-img-instead-of-qcow-stre.patch
 Patch1017: 0017-quicktests-Force-VDI-format-on-creation.patch
 Patch1018: 0018-stream_vdi-Fix-last_chunk-calculation.patch
 
+# XSA-489 fixes, in v26.1.11 upstream (https://github.com/xapi-project/xen-api/pull/7034)
 Patch1019: 0019-Remove-handling-of-VBD.other_config-backend-local.patch
 Patch1020: 0020-Do-not-recognise-VM.other_config-is_system_domain.patch
 Patch1021: 0021-Do-not-recognise-VM-PBD-.other_config-storage_driver.patch
+
+# in v26.1.5 upstream (https://github.com/xapi-project/xen-api/commit/8bbfa01c84e70d231124e6dffde55a56af687a61)
+Patch1022: 0022-Refresh-remote-session-during-long-migrations.patch
+
+# XSA-489 fixes, in v26.1.11 upstream (https://github.com/xapi-project/xen-api/pull/7046)
+Patch1023: 0023-xapi_vm-Implement-RBAC-checking-for-keys-in-set_othe.patch
+Patch1024: 0024-xapi_vm-Implement-per-key-RBAC-checking-for-VM.platf.patch
+Patch1025: 0025-idl-Update-the-schematest-hash.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1520,6 +1529,10 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Thu Apr 30 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 26.1.3-1.10
+- Fix for expiring sessions breaking long migrations
+- More fixes for XSA-489 (CVE-2026-23562, CVE-2026-42486)
+
 * Mon Apr 27 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.3-1.9
 - Fixes for XSA-489 (CVE-2026-23559, CVE-2026-23560, CVE-2026-23561)
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3236

#### Context & Motivation

Backport of https://github.com/xapi-project/xen-api/pull/7034, https://github.com/xapi-project/xen-api/pull/7046, https://github.com/xapi-project/xen-api/commit/8bbfa01c84e70d231124e6dffde55a56af687a61


#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

Ready for today's release, if we decide to go for it.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

This fixes XSA-489 (CVE-2026-23562, CVE-2026-42486) and fixes an issue where expired sessions would break long migrations

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

None that are known

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

None, the build should be run through the CI. XSA backports have been tested by XenServer.

#### What's covered by the xcp-ng-tests test suite?

We don't use the xapi RBAC roles, we don't use `hvm_serial` .

We have a lot of VM/VDI migration tests, with the large QCOW2 volumes taking more than 24h to migrate - these should verify the session refresh patches.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
