### PR TITLE
Don't deny smartcards in usb-policy.conf

### DIFF
--- a/SOURCES/0020-Don-t-deny-smartcards-in-usb-policy.conf.patch
+++ b/SOURCES/0020-Don-t-deny-smartcards-in-usb-policy.conf.patch
@@ -1,0 +1,34 @@
+From fb485a1f30f47151b23b988d31aed56c4c60ba10 Mon Sep 17 00:00:00 2001
+From: Tu Dinh <ngoc-tu.dinh@vates.tech>
+Date: Fri, 20 Mar 2026 13:40:16 +0100
+Subject: [PATCH] Don't deny smartcards in usb-policy.conf
+
+Backport of 651a7b9da1d3c4ec009782bca330bac5d05a4111.
+
+Removing this device class from the USB config would let admins
+configure VMs for digital signing purposes.
+
+These devices are also not very useful in Dom0.
+
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+(cherry picked from commit 30af482f9db7e483a519a95e89ef13afb25200bd)
+
+Origin: https://github.com/xapi-project/xen-api/pull/6967
+Bug-Vates: XCPNG-3307
+Signed-off-by: Tu Dinh <ngoc-tu.dinh@vates.tech>
+---
+ scripts/usb-policy.conf | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/usb-policy.conf b/scripts/usb-policy.conf
+index e14a11d68..c851ab6cf 100644
+--- a/scripts/usb-policy.conf
++++ b/scripts/usb-policy.conf
+@@ -20,7 +20,6 @@ ALLOW:vid=056a pid=00fb class=03 # Wacom DTU tablet
+ DENY: class=03 subclass=01 prot=01 # HID Boot keyboards
+ DENY: class=03 subclass=01 prot=02 # HID Boot mice
+ DENY: class=0a # CDC-Data
+-DENY: class=0b # Smartcard
+ DENY: class=e0 # Wireless controller
+ DENY: class=ef subclass=04 # Miscellaneous network devices
+ ALLOW: # Otherwise allow everything else

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.4
-Release: 3%{?xsrel}.1%{?dist}
+Release: 3%{?xsrel}.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -125,6 +125,9 @@ Patch1018: 0018-stream_vdi-Fix-last_chunk-calculation.patch
 
 # in v26.1.5 upstream (https://github.com/xapi-project/xen-api/commit/8bbfa01c84e70d231124e6dffde55a56af687a61)
 Patch1019: 0019-Refresh-remote-session-during-long-migrations.patch
+
+# in v26.1.7 upstream
+Patch1020: 0020-Don-t-deny-smartcards-in-usb-policy.conf.patch
 
 
 %{?_cov_buildrequires}
@@ -1526,6 +1529,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Fri May 22 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 26.1.4-3.2
+- Don't deny smartcards in usb-policy.conf
+
 * Tue May 12 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.4-3.1
 - Update to upstream 26.1.4-3
 - *** Upstream changelog ***


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3307

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

Backport of https://github.com/xapi-project/xen-api/pull/6967.

I use smartcards in XCP-ng and it's annoying having to ask to change the usb-policy.conf every update.

#### Release Target

- [ ] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [x] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

Ideally 8.3-next but not sure if the xapi team wants another target?

=> 8.3-next validated by XAPI team and release team.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Enable USB passthrough of smartcards

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

usb-policy.conf is managed by the xapi package and any manual changes by the user will be wiped out on upgrade. This PR doesn't change that, but is worth noting.

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

AFAIK usb-policy.conf is not documented formally

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Installation
Manually verified usb-policy-conf contents

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Manual test of USB passthrough
- Is USB passthrough of existing devices functional?
- Do smartcard devices show up in the VUSB menu of Xen Orchestra? Can users attach them to their VM and have them function normally without further configuration?

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

N/A, not currently covered.

#### What tests have been or will be added to CI for this change? If none, explain why.

USB passthrough tests as a whole should be added. Card created for future improvement: XCPNG-3308

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->