### PR TITLE
XCPNG-2410: Implement better VM revert using VDI revert

### DIFF
--- a/SOURCES/0021-gitignore-ignore-_mock-directory.patch
+++ b/SOURCES/0021-gitignore-ignore-_mock-directory.patch
@@ -1,0 +1,27 @@
+From 99dfa126939bad02504b33adb704c7bf711040ca Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Tue, 19 May 2026 14:13:28 +0100
+Subject: [PATCH] gitignore: ignore _mock directory
+
+used for running dune in a build root without conflicting with the
+normal _build that is used by editors or other tools
+
+This separate directory can be used by setting an environment variable:
+
+    DUNE_BUILD_DIR=_mock dune build ocaml/quicktest/ --profile=release -w
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ .gitignore | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/.gitignore b/.gitignore
+index 93ad84407..c68c675a0 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -1,4 +1,5 @@
+ _build/
++_mock/
+ *.bak
+ *.native
+ .merlin

--- a/SOURCES/0022-record_util-move-to-a-new-private-library.patch
+++ b/SOURCES/0022-record_util-move-to-a-new-private-library.patch
@@ -1,0 +1,109 @@
+From ae04b08dbe7281ce640d64fe9f6a530678c9386c Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 8 May 2026 17:10:27 +0100
+Subject: [PATCH] record_util: move to a new private library
+
+This module can help with printing API types, so move it to a new
+private library so it can be used without compiling the cli server. This
+is especially interesting for unit tests.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/tests/dune             |  2 ++
+ ocaml/tests/record_util/dune | 16 ++++++++++++----
+ ocaml/xapi-cli-server/dune   |  8 ++++++++
+ ocaml/xapi/dune              |  2 ++
+ 4 files changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/ocaml/tests/dune b/ocaml/tests/dune
+index f829e72c8..7ee0ec158 100644
+--- a/ocaml/tests/dune
++++ b/ocaml/tests/dune
+@@ -23,6 +23,7 @@
+     mirage-crypto
+     mtime
+     pam
++    record_util
+     result
+     rpclib.core
+     rpclib.json
+@@ -99,6 +100,7 @@
+     pam
+     ptime
+     result
++    record_util
+     rpclib.core
+     rpclib.json
+     rresult
+diff --git a/ocaml/tests/record_util/dune b/ocaml/tests/record_util/dune
+index a91a104da..0bce8316d 100644
+--- a/ocaml/tests/record_util/dune
++++ b/ocaml/tests/record_util/dune
+@@ -1,6 +1,14 @@
+ (test
+-	(name test_record_util)
+-	(package xapi)
+-	(libraries alcotest xapi_cli_server rpclib.core xapi_consts xapi_types astring fmt)
+-	(action (run %{test} --show-errors))
++  (name test_record_util)
++  (package xapi)
++  (libraries
++    alcotest
++    astring
++    fmt
++    record_util
++    rpclib.core
++    xapi_consts 
++    xapi_types
++    )
++  (action (run %{test} --show-errors))
+ )
+diff --git a/ocaml/xapi-cli-server/dune b/ocaml/xapi-cli-server/dune
+index fb2a713dc..992d81617 100644
+--- a/ocaml/xapi-cli-server/dune
++++ b/ocaml/xapi-cli-server/dune
+@@ -8,9 +8,16 @@
+     (run %{gen} utils --filter-internal --filter closed)))
+ )
+ 
++(library
++  (name record_util)
++  (modules generated_record_utils record_util)
++  (libraries rpclib.core xapi-consts xapi-types)
++)
++
+ (library
+   (name xapi_cli_server)
+   (modes best)
++  (modules (:standard \ generated_record_utils record_util))
+   (libraries
+     astring
+     base64
+@@ -19,6 +26,7 @@
+     rpclib.core
+     rpclib.xml
+     re
++    record_util
+     result
+     rresult
+     sexplib
+diff --git a/ocaml/xapi/dune b/ocaml/xapi/dune
+index 139bf4d0f..b2c78a30c 100644
+--- a/ocaml/xapi/dune
++++ b/ocaml/xapi/dune
+@@ -170,6 +170,7 @@
+   rpclib.json
+   rpclib.xml
+   re
++  record_util
+   result
+   rresult
+   rrd-transport.lib
+@@ -297,6 +298,7 @@
+   forkexec
+   http_lib
+   httpsvr
++  record_util
+   rpclib.core
+   rpclib.json
+   rpclib.xml

--- a/SOURCES/0023-ocaml-tests-separate-test_sr_allowed_operations.patch
+++ b/SOURCES/0023-ocaml-tests-separate-test_sr_allowed_operations.patch
@@ -1,0 +1,80 @@
+From 30b4778518f0a2f7053d75c6430387fbbdf6965a Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Mon, 9 Feb 2026 15:40:53 +0100
+Subject: [PATCH] ocaml/tests: separate test_sr_allowed_operations
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/tests/dune                           | 7 ++++---
+ ocaml/tests/suite_alcotest.ml              | 1 -
+ ocaml/tests/test_sr_allowed_operations.ml  | 5 +++++
+ ocaml/tests/test_sr_allowed_operations.mli | 0
+ 4 files changed, 9 insertions(+), 4 deletions(-)
+ create mode 100644 ocaml/tests/test_sr_allowed_operations.mli
+
+diff --git a/ocaml/tests/dune b/ocaml/tests/dune
+index 7ee0ec158..2f51f4f12 100644
+--- a/ocaml/tests/dune
++++ b/ocaml/tests/dune
+@@ -9,7 +9,7 @@
+       test_vm_placement test_vm_helpers test_repository test_repository_helpers
+       test_ref test_xapi_helpers test_vm_group
+       test_livepatch test_rpm test_updateinfo test_storage_smapiv1_wrapper test_storage_quicktest test_observer
+-      test_pool_periodic_update_sync test_pkg_mgr test_tar_ext test_pool_repository))
++      test_pool_periodic_update_sync test_pkg_mgr test_tar_ext test_pool_repository test_sr_allowed_operations))
+   (libraries
+     alcotest
+     angstrom
+@@ -84,14 +84,14 @@
+   (names test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt test_bounded_psq test_auth_cache
+     test_clustering test_pusb test_daemon_manager test_repository test_repository_helpers
+     test_livepatch test_rpm test_updateinfo test_pool_periodic_update_sync test_pkg_mgr
+-    test_xapi_helpers test_tar_ext test_pool_repository)
++      test_xapi_helpers test_tar_ext test_pool_repository test_sr_allowed_operations)
+   (package xapi)
+   (modes exe)
+   (modules test_vm_helpers test_vm_placement test_network_sriov test_vdi_cbt test_bounded_psq test_auth_cache
+     test_event test_clustering test_cluster_host test_cluster test_pusb
+     test_daemon_manager test_repository test_repository_helpers test_livepatch test_rpm
+     test_updateinfo test_pool_periodic_update_sync test_pkg_mgr
+-    test_xapi_helpers test_tar_ext test_pool_repository)
++    test_xapi_helpers test_tar_ext test_pool_repository test_sr_allowed_operations)
+   (libraries
+     alcotest
+     bos
+@@ -116,6 +116,7 @@
+     xapi-idl.storage.interface
+     xapi-idl.xen
+     clock
++    xapi-log
+     xapi-stdext-threads
+     xapi-stdext-threads.scheduler
+     xapi-stdext-unix
+diff --git a/ocaml/tests/suite_alcotest.ml b/ocaml/tests/suite_alcotest.ml
+index 5cbd192e9..a444d37b1 100644
+--- a/ocaml/tests/suite_alcotest.ml
++++ b/ocaml/tests/suite_alcotest.ml
+@@ -8,7 +8,6 @@ let () =
+        ("Test_sdn_controller", Test_sdn_controller.test)
+      ; ("Test_pci_helpers", Test_pci_helpers.test)
+      ; ("Test_vdi_allowed_operations", Test_vdi_allowed_operations.test)
+-     ; ("Test_sr_allowed_operations", Test_sr_allowed_operations.test)
+      ; ("Test_vm_migrate", Test_vm_migrate.test)
+      ; ("Test_no_migrate", Test_no_migrate.test)
+      ; ("Test_vm_check_operation_error", Test_vm_check_operation_error.test)
+diff --git a/ocaml/tests/test_sr_allowed_operations.ml b/ocaml/tests/test_sr_allowed_operations.ml
+index 8fca69f67..095597aa4 100644
+--- a/ocaml/tests/test_sr_allowed_operations.ml
++++ b/ocaml/tests/test_sr_allowed_operations.ml
+@@ -72,3 +72,8 @@ let test_operations_restricted_during_rpu =
+   [("test_check_operation_error", `Quick, test_check_operation_error)]
+ 
+ let test = test_operations_restricted_during_rpu
++
++let () =
++  Suite_init.harness_init () ;
++  Debug.log_to_stdout () ;
++  Alcotest.run "Base suite" [("Test_sr_allowed_operations", test)]
+diff --git a/ocaml/tests/test_sr_allowed_operations.mli b/ocaml/tests/test_sr_allowed_operations.mli
+new file mode 100644
+index 000000000..e69de29bb

--- a/SOURCES/0024-xapi_sr_operations-use-results-for-asserting-valid-o.patch
+++ b/SOURCES/0024-xapi_sr_operations-use-results-for-asserting-valid-o.patch
@@ -1,0 +1,131 @@
+From e8ab9409e3d51c9a76ebb37c174b79a4936e7b52 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Tue, 10 Feb 2026 09:22:52 +0100
+Subject: [PATCH] xapi_sr_operations: use results for asserting valid ops
+
+Makes the distinction between the absence of a value and absence of an
+error.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_sr_operations.ml | 43 ++++++++++++++++++++------------
+ quality-gate.sh                  |  2 +-
+ 2 files changed, 28 insertions(+), 17 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_sr_operations.ml b/ocaml/xapi/xapi_sr_operations.ml
+index 8d9d67e58..a9f3bf7eb 100644
+--- a/ocaml/xapi/xapi_sr_operations.ml
++++ b/ocaml/xapi/xapi_sr_operations.ml
+@@ -93,7 +93,7 @@ let sm_cap_table : (API.storage_operations * _) list =
+     (`vdi_snapshot, Vdi_snapshot)
+   ]
+ 
+-type table = (API.storage_operations, (string * string list) option) Hashtbl.t
++type table = (API.storage_operations, (unit, exn) Result.t) Hashtbl.t
+ 
+ let features_of_sr_internal ~__context ~_type =
+   match
+@@ -113,22 +113,30 @@ let features_of_sr_internal ~__context ~_type =
+ let features_of_sr ~__context record =
+   features_of_sr_internal ~__context ~_type:record.Db_actions.sR_type
+ 
+-(** Returns a table of operations -> API error options (None if the operation would be ok)
+- * If op is specified, the table may omit reporting errors for ops other than that one. *)
++(** Returns a table of operations -> API error options (None if the operation
++    would be ok) If op is specified, the table may omit reporting errors for
++    ops other than that one. *)
+ let valid_operations ~__context ?op record _ref' : table =
+   let _ref = Ref.string_of _ref' in
+   let current_ops = record.Db_actions.sR_current_operations in
+   let table : table = Hashtbl.create 10 in
+-  List.iter (fun x -> Hashtbl.replace table x None) all_ops ;
++  List.iter (fun x -> Hashtbl.replace table x (Ok ())) all_ops ;
+   let set_errors (code : string) (params : string list)
+       (ops : API.storage_operations_set) =
+     List.iter
+       (fun op ->
+-        (* Exception can't be raised since the hash table is
+-           pre-filled for all_ops, and set_errors is applied
+-           to a subset of all_ops (disallowed_during_rpu) *)
+-        if Hashtbl.find table op = None then
+-          Hashtbl.replace table op (Some (code, params))
++        match Hashtbl.find_opt table op with
++        | Some (Ok ()) ->
++            Hashtbl.replace table op
++              (Error (Api_errors.Server_error (code, params)))
++        | Some (Error _) ->
++            (* Don't replace existing errors *)
++            ()
++        | None ->
++            (* Ignore order if the operation is not in table, this is a coding
++               error, as all calls to set_errors should be a subset of all_ops
++               *)
++            ()
+       )
+       ops
+   in
+@@ -143,7 +151,8 @@ let valid_operations ~__context ?op record _ref' : table =
+     let open Smint.Feature in
+     (* First consider the backend SM features *)
+     let sm_features = features_of_sr ~__context record in
+-    (* Then filter out the operations we don't want to see for the magic tools SR *)
++    (* Then filter out the operations we don't want to see for the magic tools
++       SR *)
+     let sm_features =
+       if record.Db_actions.sR_is_tools_sr then
+         List.filter
+@@ -163,7 +172,8 @@ let valid_operations ~__context ?op record _ref' : table =
+     set_errors Api_errors.sr_operation_not_supported [_ref] forbidden_by_backend
+   in
+   let check_any_attached_pbds ~__context _record =
+-    (* CA-70294: if the SR has any attached PBDs, destroy and forget operations are not allowed.*)
++    (* CA-70294: if the SR has any attached PBDs, destroy and forget operations
++       are not allowed.*)
+     let all_pbds_attached_to_this_sr =
+       Db.PBD.get_records_where ~__context
+         ~expr:
+@@ -237,7 +247,8 @@ let valid_operations ~__context ?op record _ref' : table =
+       Cluster_stack_constraints.assert_cluster_stack_compatible ~__context _ref'
+     with Api_errors.Server_error (e, args) -> set_errors e args [`plug]
+   in
+-  (* List of (operations * function which checks for errors relevant to those operations) *)
++  (* List of (operations * function which checks for errors relevant to those
++     operations) *)
+   let relevant_functions =
+     [
+       (all_ops, check_sm_features)
+@@ -264,9 +275,9 @@ let throw_error (table : table) op =
+       Helpers.internal_error
+         "xapi_sr.assert_operation_valid unknown operation: %s"
+         (sr_operation_to_string op)
+-  | Some (Some (code, params)) ->
+-      raise (Api_errors.Server_error (code, params))
+-  | Some None ->
++  | Some (Error ex) ->
++      raise ex
++  | Some (Ok ()) ->
+       ()
+ 
+ let assert_operation_valid ~__context ~self ~(op : API.storage_operations) =
+@@ -280,7 +291,7 @@ let update_allowed_operations ~__context ~self : unit =
+   let keys =
+     Hashtbl.fold
+       (fun k v acc ->
+-        if v = None then
++        if v = Ok () then
+           k :: acc
+         else
+           acc
+diff --git a/quality-gate.sh b/quality-gate.sh
+index 882ef263c..54fd5adc4 100755
+--- a/quality-gate.sh
++++ b/quality-gate.sh
+@@ -110,7 +110,7 @@ unixgetenv () {
+ }
+ 
+ hashtblfind () {
+-  N=33
++  N=32
+   # Looks for all .ml files except the ones using Core.Hashtbl.find,
+   # which already returns Option
+   HASHTBLFIND=$(git grep -P -r --count 'Hashtbl.find(?!_opt)' -- '**/*.ml' ':!ocaml/xapi-storage-script/main.ml' | cut -d ':' -f 2 | paste -sd+ - | bc)

--- a/SOURCES/0025-xapi_sr_operations-ensure-the-properties-on-ops-list.patch
+++ b/SOURCES/0025-xapi_sr_operations-ensure-the-properties-on-ops-list.patch
@@ -1,0 +1,184 @@
+From 63a3869fcaac5f249ed61e1a4418b60d6e6e4d4d Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Mon, 9 Feb 2026 10:31:47 +0100
+Subject: [PATCH] xapi_sr_operations: ensure the properties on ops lists always
+ hold
+
+The lists of operations used in the module need to be a subset of
+all_ops, otherwise spurious errors can be thrown on runtime.
+
+Ensuring these properties allows to drop the runtime check
+
+Also add an interface file for the module
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/tests/dune                        | 14 +++++---
+ ocaml/tests/test_xapi_sr_operations.ml  | 44 +++++++++++++++++++++++++
+ ocaml/tests/test_xapi_sr_operations.mli |  0
+ ocaml/xapi/xapi_sr_operations.ml        |  6 +---
+ ocaml/xapi/xapi_sr_operations.mli       | 40 ++++++++++++++++++++++
+ quality-gate.sh                         |  2 +-
+ 6 files changed, 96 insertions(+), 10 deletions(-)
+ create mode 100644 ocaml/tests/test_xapi_sr_operations.ml
+ create mode 100644 ocaml/tests/test_xapi_sr_operations.mli
+ create mode 100644 ocaml/xapi/xapi_sr_operations.mli
+
+diff --git a/ocaml/tests/dune b/ocaml/tests/dune
+index 2f51f4f12..4908fd193 100644
+--- a/ocaml/tests/dune
++++ b/ocaml/tests/dune
+@@ -132,12 +132,18 @@
+   (preprocess (per_module ((pps ppx_deriving_rpc) Test_cluster_host)))
+ )
+ 
+-(test
+-(name test_storage_smapiv1_wrapper)
++(tests
++(names test_storage_smapiv1_wrapper test_xapi_sr_operations)
+ (modes exe)
+ (package xapi)
+-(modules test_storage_smapiv1_wrapper)
+-(libraries alcotest xapi_internal fmt xapi-idl.storage.interface xapi-idl.storage.interface.types))
++(modules test_storage_smapiv1_wrapper test_xapi_sr_operations)
++(libraries
++  alcotest
++  fmt
++  record_util
++  xapi-idl.storage.interface
++  xapi-idl.storage.interface.types
++  xapi_internal))
+ 
+ (test
+ (name test_storage_quicktest)
+diff --git a/ocaml/tests/test_xapi_sr_operations.ml b/ocaml/tests/test_xapi_sr_operations.ml
+new file mode 100644
+index 000000000..5045c5e8f
+--- /dev/null
++++ b/ocaml/tests/test_xapi_sr_operations.ml
+@@ -0,0 +1,44 @@
++(*
++  Copyright (C) 2026 Vates.
++ 
++  This program is free software; you can redistribute it and/or modify
++  it under the terms of the GNU Lesser General Public License as published
++  by the Free Software Foundation; version 2.1 only. with the special
++  exception on linking described in file LICENSE.
++ 
++  This program is distributed in the hope that it will be useful,
++  but WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++  GNU Lesser General Public License for more details.
++ *)
++
++module Ops = Xapi_sr_operations
++
++let contained_tables =
++  [
++    (Ops.all_rpu_ops, "all_rpu_ops")
++  ; (Ops.disallowed_during_rpu, "disallowed_during_rpu")
++  ; (Ops.sm_cap_table |> List.map fst, "sm_cap_table")
++  ]
++
++let not_contained element =
++  if not (List.mem element Ops.all_ops) then
++    Some (Record_util.storage_operations_to_string element)
++  else
++    None
++
++let test_tables =
++  List.map
++    (fun (input, name) ->
++      let test () =
++        let not_contained = List.filter_map not_contained input in
++        Alcotest.(check @@ list string)
++          "There cannot be operations missing from all_ops" [] not_contained
++      in
++      (Printf.sprintf {|%s is a subset of all_ops|} name, `Quick, test)
++    )
++    contained_tables
++
++let () =
++  Alcotest.run "Test XAPI Helpers suite"
++    [("SR operation tables all are complete ", test_tables)]
+diff --git a/ocaml/tests/test_xapi_sr_operations.mli b/ocaml/tests/test_xapi_sr_operations.mli
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/ocaml/xapi/xapi_sr_operations.ml b/ocaml/xapi/xapi_sr_operations.ml
+index a9f3bf7eb..e74e19863 100644
+--- a/ocaml/xapi/xapi_sr_operations.ml
++++ b/ocaml/xapi/xapi_sr_operations.ml
+@@ -271,13 +271,9 @@ let valid_operations ~__context ?op record _ref' : table =
+ 
+ let throw_error (table : table) op =
+   match Hashtbl.find_opt table op with
+-  | None ->
+-      Helpers.internal_error
+-        "xapi_sr.assert_operation_valid unknown operation: %s"
+-        (sr_operation_to_string op)
+   | Some (Error ex) ->
+       raise ex
+-  | Some (Ok ()) ->
++  | None | Some (Ok ()) ->
+       ()
+ 
+ let assert_operation_valid ~__context ~self ~(op : API.storage_operations) =
+diff --git a/ocaml/xapi/xapi_sr_operations.mli b/ocaml/xapi/xapi_sr_operations.mli
+new file mode 100644
+index 000000000..e4fce0189
+--- /dev/null
++++ b/ocaml/xapi/xapi_sr_operations.mli
+@@ -0,0 +1,40 @@
++type table = (API.storage_operations, (unit, exn) Result.t) Hashtbl.t
++
++val features_of_sr_internal :
++  __context:Context.t -> _type:string -> (Smint.Feature.capability * int64) list
++
++val features_of_sr :
++     __context:Context.t
++  -> Db_actions.sR_t
++  -> (Smint.Feature.capability * int64) list
++
++val assert_operation_valid :
++     __context:Context.t
++  -> self:[`SR] API.Ref.t
++  -> op:API.storage_operations
++  -> unit
++
++val update_allowed_operations :
++  __context:Context.t -> self:[`SR] API.Ref.t -> unit
++
++val cancel_tasks :
++     __context:Context.t
++  -> self:[`SR] API.Ref.t
++  -> all_tasks_in_db:[`task] Ref.t list
++  -> task_ids:string list
++  -> unit
++
++val sr_health_check : __context:Context.t -> self:[`SR] API.Ref.t -> unit
++
++val stop_health_check_thread :
++  __context:Context.t -> self:[`SR] API.Ref.t -> unit
++
++(**/**)
++
++val all_ops : API.storage_operations_set
++
++val all_rpu_ops : API.storage_operations_set
++
++val disallowed_during_rpu : API.storage_operations_set
++
++val sm_cap_table : (API.storage_operations * Smint.Feature.capability) list
+diff --git a/quality-gate.sh b/quality-gate.sh
+index 54fd5adc4..c1df9d96f 100755
+--- a/quality-gate.sh
++++ b/quality-gate.sh
+@@ -25,7 +25,7 @@ verify-cert () {
+ }
+ 
+ mli-files () {
+-  N=456
++  N=455
+   X="ocaml/tests"
+   X+="|ocaml/quicktest"
+   X+="|ocaml/message-switch/core_test"

--- a/SOURCES/0026-xapi-storage-add-interface-to-common.patch
+++ b/SOURCES/0026-xapi-storage-add-interface-to-common.patch
@@ -1,0 +1,86 @@
+From 73b40e39723b4f68f3458b9aad99fc20164b9b9b Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Thu, 2 Oct 2025 10:12:15 +0100
+Subject: [PATCH] xapi-storage: add interface to common
+
+avoids having unused bindings
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi-storage/generator/lib/common.ml  | 13 +---------
+ ocaml/xapi-storage/generator/lib/common.mli | 28 +++++++++++++++++++++
+ quality-gate.sh                             |  2 +-
+ 3 files changed, 30 insertions(+), 13 deletions(-)
+ create mode 100644 ocaml/xapi-storage/generator/lib/common.mli
+
+diff --git a/ocaml/xapi-storage/generator/lib/common.ml b/ocaml/xapi-storage/generator/lib/common.ml
+index 2c1440275..23d0573e5 100644
+--- a/ocaml/xapi-storage/generator/lib/common.ml
++++ b/ocaml/xapi-storage/generator/lib/common.ml
+@@ -22,18 +22,7 @@ let dbg =
+ 
+ let unit = Param.mk Types.unit
+ 
+-let task_id = Param.mk ~name:"task_id" Types.string
+-
+-(** A URI representing the means for accessing the volume data. The
+-    interpretation of the URI is specific to the implementation. Xapi will
+-    choose which implementation to use based on the URI scheme. *)
+ type uri = string [@@deriving rpcty]
+ 
+-(** List of blocks for copying. *)
+-type blocklist = {
+-    blocksize: int  (** Size of the individual blocks. *)
+-  ; ranges: (int64 * int64) list
+-        (** List of block ranges, where a range is a (start,length) pair,
+-          measured in units of [blocksize] *)
+-}
++type blocklist = {blocksize: int; ranges: (int64 * int64) list}
+ [@@deriving rpcty]
+diff --git a/ocaml/xapi-storage/generator/lib/common.mli b/ocaml/xapi-storage/generator/lib/common.mli
+new file mode 100644
+index 000000000..6820a0bf5
+--- /dev/null
++++ b/ocaml/xapi-storage/generator/lib/common.mli
+@@ -0,0 +1,28 @@
++type exnt = Unimplemented of string
++
++val typ_of_exnt : exnt Rpc.Types.typ
++
++val exnt : exnt Rpc.Types.def
++
++exception DataExn of exnt
++
++val error : exnt Idl.Error.t
++
++val dbg : string Idl.Param.t
++
++val unit : unit Idl.Param.t
++
++val uri : string Rpc.Types.def
++(** A URI representing the means for accessing the volume data. The
++    interpretation of the URI is specific to the implementation. Xapi will
++    choose which implementation to use based on the URI scheme. *)
++
++(** List of blocks for copying. *)
++type blocklist = {
++    blocksize: int  (** Size of the individual blocks. *)
++  ; ranges: (int64 * int64) list
++        (** List of block ranges, where a range is a (start,length) pair,
++          measured in units of [blocksize] *)
++}
++
++val blocklist : blocklist Rpc.Types.def
+diff --git a/quality-gate.sh b/quality-gate.sh
+index c1df9d96f..647482fff 100755
+--- a/quality-gate.sh
++++ b/quality-gate.sh
+@@ -25,7 +25,7 @@ verify-cert () {
+ }
+ 
+ mli-files () {
+-  N=455
++  N=454
+   X="ocaml/tests"
+   X+="|ocaml/quicktest"
+   X+="|ocaml/message-switch/core_test"

--- a/SOURCES/0027-xapi_vdi-removed-code-commented-in-the-prehistoric-t.patch
+++ b/SOURCES/0027-xapi_vdi-removed-code-commented-in-the-prehistoric-t.patch
@@ -1,0 +1,53 @@
+From 6af4461d4e932075afb2f286933e3c2d9a2e6c9d Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 24 Sep 2025 14:13:05 +0100
+Subject: [PATCH] xapi_vdi: removed code commented in the prehistoric times
+
+That's pre-2009 in xapi land
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_vdi.ml | 30 ------------------------------
+ 1 file changed, 30 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vdi.ml b/ocaml/xapi/xapi_vdi.ml
+index 1d4b881c4..7ce251f08 100644
+--- a/ocaml/xapi/xapi_vdi.ml
++++ b/ocaml/xapi/xapi_vdi.ml
+@@ -532,36 +532,6 @@ let cancel_tasks ~__context ~self ~all_tasks_in_db ~task_ids =
+ 
+ (**************************************************************************************)
+ 
+-(* Helper function to create a new VDI record with all fields copied from
+-   an original, except ref and *_operations, UUID and others supplied as optional arguments.
+-   If a new UUID is not supplied, a fresh one is generated.
+-   storage_lock defaults to false.
+-   Parent defaults to Ref.null.
+-*)
+-(*let clone_record ~uuid ?name_label ?name_description ?sR ?virtual_size ?location
+-    ?physical_utilisation ?_type ?sharable ?read_only ?storage_lock ?other_config ?parent
+-    ?xenstore_data ?sm_config ~current_operations ~__context ~original () =
+-  let a = Db.VDI.get_record_internal ~__context ~self:original in
+-  let r = Ref.make () in
+-  Db.VDI.create ~__context ~ref:r
+-    ~uuid:(Uuidx.to_string uuid)
+-    ~name_label:(default a.Db_actions.vDI_name_label name_label)
+-    ~name_description:(default a.Db_actions.vDI_name_description name_description)
+-    ~allowed_operations:[] ~current_operations
+-    ~sR:(default a.Db_actions.vDI_SR sR)
+-    ~virtual_size:(default a.Db_actions.vDI_virtual_size virtual_size)
+-    ~physical_utilisation:(default a.Db_actions.vDI_physical_utilisation physical_utilisation)
+-    ~_type:(default a.Db_actions.vDI_type _type)
+-    ~sharable:(default a.Db_actions.vDI_sharable sharable)
+-    ~read_only:(default a.Db_actions.vDI_read_only read_only)
+-    ~other_config:(default a.Db_actions.vDI_other_config other_config)
+-    ~storage_lock:(default false storage_lock)
+-    ~location:(default a.Db_actions.vDI_location location) ~managed:true ~missing:false
+-    ~xenstore_data:(default a.Db_actions.vDI_xenstore_data xenstore_data)
+-    ~sm_config:(default a.Db_actions.vDI_sm_config sm_config)
+-    ~parent:(default Ref.null parent);
+-  r*)
+-
+ (* This function updates xapi's database for a single VDI. The row will be created if it doesn't exist *)
+ let update_vdi_db ~__context ~sr newvdi =
+   let open Xapi_database.Db_filter_types in

--- a/SOURCES/0028-quicktest-reduce-amount-of-repetition-in-snapshot-te.patch
+++ b/SOURCES/0028-quicktest-reduce-amount-of-repetition-in-snapshot-te.patch
@@ -1,0 +1,306 @@
+From 4afb3d64f4eff20fc479ad3713b756ef6408d5e3 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 15 May 2026 15:27:31 +0100
+Subject: [PATCH] quicktest: reduce amount of repetition in snapshot tests
+
+No change in behaviour
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/quicktest/qt.ml                     |  20 ++-
+ ocaml/quicktest/qt.mli                    |   2 +
+ ocaml/quicktest/quicktest_vm_snapshot.ml  | 189 +++++++++-------------
+ ocaml/quicktest/quicktest_vm_snapshot.mli |  13 ++
+ 4 files changed, 106 insertions(+), 118 deletions(-)
+ create mode 100644 ocaml/quicktest/quicktest_vm_snapshot.mli
+
+diff --git a/ocaml/quicktest/qt.ml b/ocaml/quicktest/qt.ml
+index 49eeffc56..97b1013f4 100644
+--- a/ocaml/quicktest/qt.ml
++++ b/ocaml/quicktest/qt.ml
+@@ -180,23 +180,27 @@ module VDI = struct
+ 
+   let test_vdi_name_description = "VDI for storage quicktest"
+ 
+-  let make rpc session_id ?(virtual_size = 4194304L) ?backing_format sR =
++  let make rpc session_id ?(virtual_size = 4194304L) ?backing_format
++      ?(name_label = test_vdi_name_label)
++      ?(name_description = test_vdi_name_description) sR =
+     let sm_config =
+       match backing_format with Some x -> [("image-format", x)] | None -> []
+     in
+-    Client.Client.VDI.create ~sR ~session_id ~rpc
+-      ~name_label:test_vdi_name_label
+-      ~name_description:test_vdi_name_description ~_type:`user ~sharable:false
+-      ~read_only:false ~virtual_size ~xenstore_data:[] ~other_config:[] ~tags:[]
+-      ~sm_config
++    Client.Client.VDI.create ~sR ~session_id ~rpc ~name_label ~name_description
++      ~_type:`user ~sharable:false ~read_only:false ~virtual_size
++      ~xenstore_data:[] ~other_config:[] ~tags:[] ~sm_config
+ 
+   let with_destroyed rpc session_id self f =
+     Xapi_stdext_pervasives.Pervasiveext.finally f (fun () ->
+         Client.Client.VDI.destroy ~rpc ~session_id ~self
+     )
+ 
+-  let with_new rpc session_id ?(virtual_size = 4194304L) ?backing_format sr f =
+-    let self = make rpc session_id ~virtual_size ?backing_format sr in
++  let with_new rpc session_id ?(virtual_size = 4194304L) ?backing_format
++      ?name_label ?name_description sr f =
++    let self =
++      make rpc session_id ~virtual_size ?backing_format ?name_label
++        ?name_description sr
++    in
+     with_destroyed rpc session_id self (fun () -> f self)
+ 
+   let with_any rpc session_id sr_info f =
+diff --git a/ocaml/quicktest/qt.mli b/ocaml/quicktest/qt.mli
+index 6423c6060..e4c22246f 100644
+--- a/ocaml/quicktest/qt.mli
++++ b/ocaml/quicktest/qt.mli
+@@ -74,6 +74,8 @@ module VDI : sig
+     -> API.ref_session
+     -> ?virtual_size:int64
+     -> ?backing_format:string
++    -> ?name_label:string
++    -> ?name_description:string
+     -> API.ref_SR
+     -> (API.ref_VDI -> 'a)
+     -> 'a
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index f6e976bb2..2af0cb79c 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -1,123 +1,95 @@
++(* Copyright (C) 2026 Vates.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as published
++   by the Free Software Foundation; version 2.1 only. with the special
++   exception on linking described in file LICENSE.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++*)
++let ( let@ ) f x = f x
++
++let create_vbd_disk rpc session_id vm vdi n =
++  Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:n
++    ~bootable:false ~mode:`RW ~_type:`Disk ~unpluggable:true ~empty:false
++    ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
++    ~currently_attached:true
++
+ (** Set up snapshot test: create a small VM with a selection of VBDs *)
+ let with_setup rpc session_id sr vm_template f =
+   print_endline "Setting up test VM" ;
+   let uuid = Client.Client.VM.get_uuid ~rpc ~session_id ~self:vm_template in
+   print_endline (Printf.sprintf "Template has uuid: %s%!" uuid) ;
+-  let vdi =
+-    Client.Client.VDI.create ~rpc ~session_id ~name_label:"small"
+-      ~name_description:__LOC__ ~sR:sr ~virtual_size:4194304L ~_type:`user
+-      ~sharable:false ~read_only:false ~other_config:[] ~xenstore_data:[]
+-      ~sm_config:[] ~tags:[]
++  let@ vm = Qt.VM.with_new rpc session_id ~template:vm_template ~sr in
++  print_endline (Printf.sprintf "Installed new VM") ;
++  print_endline
++    (Printf.sprintf "Using SR: %s"
++       (Client.Client.SR.get_name_label ~rpc ~session_id ~self:sr)
++    ) ;
++  let@ vdi =
++    Qt.VDI.with_new rpc session_id ~name_label:"small" ~name_description:__LOC__
++      ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
++      sr
+   in
+-  let vdi2 =
+-    Client.Client.VDI.create ~rpc ~session_id ~name_label:"small2"
+-      ~name_description:__LOC__ ~sR:sr ~virtual_size:4194304L ~_type:`user
+-      ~sharable:false ~read_only:false ~other_config:[] ~xenstore_data:[]
+-      ~sm_config:[] ~tags:[]
++  ignore (create_vbd_disk rpc session_id vm vdi "0") ;
++  let@ vdi2 =
++    Qt.VDI.with_new rpc session_id ~name_label:"small2"
++      ~name_description:__LOC__
++      ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
++      sr
+   in
+-  Qt.VM.with_new rpc session_id ~template:vm_template (fun vm ->
+-      print_endline (Printf.sprintf "Installed new VM") ;
+-      print_endline
+-        (Printf.sprintf "Using SR: %s"
+-           (Client.Client.SR.get_name_label ~rpc ~session_id ~self:sr)
+-        ) ;
+-      ignore
+-        (Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi
+-           ~userdevice:"0" ~bootable:false ~mode:`RW ~_type:`Disk
+-           ~unpluggable:true ~empty:false ~other_config:[]
+-           ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
+-           ~currently_attached:true
+-        ) ;
+-      ignore
+-        (Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi2
+-           ~userdevice:"1" ~bootable:false ~mode:`RW ~_type:`Disk
+-           ~unpluggable:true ~empty:false ~other_config:[]
+-           ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
+-           ~currently_attached:true
+-        ) ;
+-      f rpc session_id vm vdi vdi2 ;
+-      Client.Client.VDI.destroy ~rpc ~session_id ~self:vdi ;
+-      Client.Client.VDI.destroy ~rpc ~session_id ~self:vdi2
+-  )
++  ignore (create_vbd_disk rpc session_id vm vdi2 "1") ;
++  f rpc session_id vm vdi vdi2
++
++let take_snapshot ?(ignore_vdis = []) rpc session_id vm ~origin =
++  Client.Client.VM.snapshot ~rpc ~session_id ~vm
++    ~new_name:(Printf.sprintf "Snapshot:%s" origin)
++    ~ignore_vdis
++
++let is_user_device rpc session_id n vbd =
++  Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = n
++
++let get_vdi_with_user_device rpc session_id vbds n =
++  let vbd =
++    match List.find_opt (is_user_device rpc session_id n) vbds with
++    | None ->
++        Alcotest.fail (Printf.sprintf "Couldn't find VBD on snapshot %s" n)
++    | Some vbd ->
++        vbd
++  in
++  Client.Client.VBD.get_VDI ~rpc ~session_id ~self:vbd
++
++let get_snapshot_of_vdi rpc session_id vbds n =
++  let snap = get_vdi_with_user_device rpc session_id vbds n in
++  Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap
++
++let check_vdi_snapshot_of rpc session_id vbds ~vdi n =
++  let snapshot_of = get_snapshot_of_vdi rpc session_id vbds n in
++  assert (snapshot_of = vdi)
+ 
+ let test_snapshot rpc session_id vm vdi vdi2 =
+-  let snapshot =
+-    Client.Client.VM.snapshot ~rpc ~session_id ~vm ~new_name:"Snapshot"
+-      ~ignore_vdis:[]
+-  in
++  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
+-  let snap_vbd =
+-    match
+-      List.find_opt
+-        (fun vbd ->
+-          Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "0"
+-        )
+-        vbds
+-    with
+-    | None ->
+-        Alcotest.fail "Couldn't find VBD on snapshot"
+-    | Some vbd ->
+-        vbd
+-  in
+-  let snap_vbd2 =
+-    match
+-      List.find_opt
+-        (fun vbd ->
+-          Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "1"
+-        )
+-        vbds
+-    with
+-    | None ->
+-        Alcotest.fail "Couldn't find VBD on snapshot"
+-    | Some vbd ->
+-        vbd
+-  in
+-  let snap_vdi = Client.Client.VBD.get_VDI ~rpc ~session_id ~self:snap_vbd in
+-  let snap_vdi2 = Client.Client.VBD.get_VDI ~rpc ~session_id ~self:snap_vbd2 in
+-  let orig_vdi =
+-    Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap_vdi
+-  in
+-  let orig_vdi2 =
+-    Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap_vdi2
+-  in
+-  assert (orig_vdi = vdi) ;
+-  assert (orig_vdi2 = vdi2)
++
++  check_vdi_snapshot_of rpc session_id vbds ~vdi "0" ;
++  check_vdi_snapshot_of rpc session_id vbds ~vdi:vdi2 "1"
+ 
+ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
+   let snapshot =
+-    Client.Client.VM.snapshot ~rpc ~session_id ~vm ~new_name:"Snapshot"
+-      ~ignore_vdis:[vdi2]
++    take_snapshot rpc session_id vm ~origin:__FUNCTION__ ~ignore_vdis:[vdi2]
+   in
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
+-  let snap_vbd =
+-    match
+-      List.find_opt
+-        (fun vbd ->
+-          Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "0"
+-        )
+-        vbds
+-    with
+-    | None ->
+-        Alcotest.fail "Couldn't find VBD on snapshot"
+-    | Some vbd ->
+-        vbd
++  let has_been_snapshot n =
++    List.exists (is_user_device rpc session_id n) vbds
+   in
+-  assert (
+-    not
+-      (List.exists
+-         (fun vbd ->
+-           Client.Client.VBD.get_userdevice ~rpc ~session_id ~self:vbd = "1"
+-         )
+-         vbds
+-      )
+-  ) ;
+-  let snap_vdi = Client.Client.VBD.get_VDI ~rpc ~session_id ~self:snap_vbd in
+-  let orig_vdi =
+-    Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap_vdi
+-  in
+-  assert (orig_vdi = vdi)
+ 
+-let test rpc session_id sr_info vm_template () =
++  assert (not (has_been_snapshot "1")) ;
++  check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
++
++let test_snapshots rpc session_id sr_info vm_template () =
+   let sr = sr_info.Qt.sr in
+   List.iter
+     (with_setup rpc session_id sr vm_template)
+@@ -125,10 +97,7 @@ let test rpc session_id sr_info vm_template () =
+ 
+ let tests () =
+   let open Qt_filter in
+-  [
+-    [("VM snapshot tests", `Slow, test)]
+-    |> conn
+-    |> sr SR.(all |> allowed_operations [`vdi_create])
+-    |> vm_template Qt.VM.Template.other
+-  ]
+-  |> List.concat
++  [("VM snapshot tests", `Slow, test_snapshots)]
++  |> conn
++  |> sr SR.(all |> allowed_operations [`vdi_create])
++  |> vm_template Qt.VM.Template.other
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.mli b/ocaml/quicktest/quicktest_vm_snapshot.mli
+new file mode 100644
+index 000000000..5cbc39b9e
+--- /dev/null
++++ b/ocaml/quicktest/quicktest_vm_snapshot.mli
+@@ -0,0 +1,13 @@
++(* Copyright (C) 2026 Vates.
++
++   This program is free software; you can redistribute it and/or modify
++   it under the terms of the GNU Lesser General Public License as published
++   by the Free Software Foundation; version 2.1 only. with the special
++   exception on linking described in file LICENSE.
++
++   This program is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++   GNU Lesser General Public License for more details.
++*)
++val tests : unit -> (unit -> unit) Qt_filter.test_case list

--- a/SOURCES/0029-quicktest-switch-asserts-with-alcotest-s-check-in-sn.patch
+++ b/SOURCES/0029-quicktest-switch-asserts-with-alcotest-s-check-in-sn.patch
@@ -1,0 +1,58 @@
+From fd37f01011bea60b1abe507e89b33b86ef013c8f Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 15 May 2026 15:58:23 +0100
+Subject: [PATCH] quicktest: switch asserts with alcotest's check in snapshot
+ tests
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/quicktest/quicktest_vm_snapshot.ml | 24 +++++++++++++++++++-----
+ 1 file changed, 19 insertions(+), 5 deletions(-)
+
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index 2af0cb79c..30302b84e 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -66,14 +66,27 @@ let get_snapshot_of_vdi rpc session_id vbds n =
+   let snap = get_vdi_with_user_device rpc session_id vbds n in
+   Client.Client.VDI.get_snapshot_of ~rpc ~session_id ~self:snap
+ 
+-let check_vdi_snapshot_of rpc session_id vbds ~vdi n =
+-  let snapshot_of = get_snapshot_of_vdi rpc session_id vbds n in
+-  assert (snapshot_of = vdi)
++let vm_ref : [`VM] Ref.t Alcotest.testable = Alcotest.testable Ref.pp ( = )
++
++let vdi_ref : [`VDI] Ref.t Alcotest.testable = Alcotest.testable Ref.pp ( = )
++
++let check_vm_snapshot_of rpc session_id ~snapshot ~vm =
++  let snapshot_of =
++    Client.Client.VM.get_snapshot_of ~rpc ~session_id ~self:snapshot
++  in
++  Alcotest.(check vm_ref)
++    "The expected VM is different from the one in snapshot_of" vm snapshot_of
++
++let check_vdi_snapshot_of rpc session vbds ~vdi n =
++  let snapshot_of = get_snapshot_of_vdi rpc session vbds n in
++  Alcotest.(check vdi_ref)
++    "The expected vdi is different from the one in snapshot_of" vdi snapshot_of
+ 
+ let test_snapshot rpc session_id vm vdi vdi2 =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
+ 
++  check_vm_snapshot_of rpc session_id ~snapshot ~vm ;
+   check_vdi_snapshot_of rpc session_id vbds ~vdi "0" ;
+   check_vdi_snapshot_of rpc session_id vbds ~vdi:vdi2 "1"
+ 
+@@ -85,8 +98,9 @@ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
+   let has_been_snapshot n =
+     List.exists (is_user_device rpc session_id n) vbds
+   in
+-
+-  assert (not (has_been_snapshot "1")) ;
++  Alcotest.(check bool)
++    "The vbd with user_device 1 cannot be present in the snapshot" false
++    (has_been_snapshot "1") ;
+   check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
+ 
+ let test_snapshots rpc session_id sr_info vm_template () =

--- a/SOURCES/0030-quicktest-test-reverting-snapshots.patch
+++ b/SOURCES/0030-quicktest-test-reverting-snapshots.patch
@@ -1,0 +1,85 @@
+From 62df13b2009c80044516a933663bb782c19865ea Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 15 May 2026 16:36:33 +0100
+Subject: [PATCH] quicktest: test reverting snapshots
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/quicktest/qt.ml                    |  4 ++-
+ ocaml/quicktest/quicktest_vm_snapshot.ml | 41 ++++++++++++++++++------
+ 2 files changed, 35 insertions(+), 10 deletions(-)
+
+diff --git a/ocaml/quicktest/qt.ml b/ocaml/quicktest/qt.ml
+index 97b1013f4..7c74122ee 100644
+--- a/ocaml/quicktest/qt.ml
++++ b/ocaml/quicktest/qt.ml
+@@ -192,7 +192,9 @@ module VDI = struct
+ 
+   let with_destroyed rpc session_id self f =
+     Xapi_stdext_pervasives.Pervasiveext.finally f (fun () ->
+-        Client.Client.VDI.destroy ~rpc ~session_id ~self
++        try Client.Client.VDI.destroy ~rpc ~session_id ~self
++        with Api_errors.Server_error ("HANDLE_INVALID", _) ->
++          (* Already destroyed, ignore *) ()
+     )
+ 
+   let with_new rpc session_id ?(virtual_size = 4194304L) ?backing_format
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index 30302b84e..b3d6c9c8d 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -82,6 +82,10 @@ let check_vdi_snapshot_of rpc session vbds ~vdi n =
+   Alcotest.(check vdi_ref)
+     "The expected vdi is different from the one in snapshot_of" vdi snapshot_of
+ 
++let check_vdis_different expected result =
++  Alcotest.(check @@ neg vdi_ref)
++    "The VDIs after a reverting a snapshot must not be the same" expected result
++
+ let test_snapshot rpc session_id vm vdi vdi2 =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
+@@ -103,15 +107,34 @@ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
+     (has_been_snapshot "1") ;
+   check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
+ 
+-let test_snapshots rpc session_id sr_info vm_template () =
++let test_revert rpc session_id vm vdi vdi2 =
++  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
++  Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
++
++  let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
++  let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
++  let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
++
++  (* Xapi forces VDI clones, the VDIs' IDs will always change *)
++  check_vdis_different vdi vdi_after ;
++  check_vdis_different vdi2 vdi_after2
++
++let a_test with_setup tests rpc session_id sr_info vm_template () =
+   let sr = sr_info.Qt.sr in
+-  List.iter
+-    (with_setup rpc session_id sr vm_template)
+-    [test_snapshot; test_snapshot_ignore_vdi]
++  List.iter (with_setup rpc session_id sr vm_template) tests
++
++let suite name with_setup tests sr_ops =
++  let open Qt_filter in
++  [(name, `Slow, a_test with_setup tests)]
++  |> conn
++  |> sr SR.(all |> allowed_operations sr_ops)
++  |> vm_template Qt.VM.Template.other
+ 
+ let tests () =
+-  let open Qt_filter in
+-  [("VM snapshot tests", `Slow, test_snapshots)]
+-  |> conn
+-  |> sr SR.(all |> allowed_operations [`vdi_create])
+-  |> vm_template Qt.VM.Template.other
++  List.concat
++    [
++      suite "VM snapshot tests" with_setup
++        [test_snapshot; test_snapshot_ignore_vdi]
++        [`vdi_create]
++    ; suite "VM revert tests" with_setup [test_revert] [`vdi_create; `vdi_clone]
++    ]

--- a/SOURCES/0031-quicktest-test-snapshot-revert-with-CDs.patch
+++ b/SOURCES/0031-quicktest-test-snapshot-revert-with-CDs.patch
@@ -1,0 +1,93 @@
+From c0261d7ade0f7ae98fc7f38cff1da72a78563e1e Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Thu, 28 May 2026 15:40:33 +0100
+Subject: [PATCH] quicktest: test snapshot revert with CDs
+
+VDIs containing only CDs are immutable and are prevented from being
+cloned.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/quicktest/quicktest_vm_snapshot.ml | 50 ++++++++++++++++++++++++
+ 1 file changed, 50 insertions(+)
+
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index b3d6c9c8d..eb758fb35 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -44,6 +44,38 @@ let with_setup rpc session_id sr vm_template f =
+   ignore (create_vbd_disk rpc session_id vm vdi2 "1") ;
+   f rpc session_id vm vdi vdi2
+ 
++let create_vbd_cd rpc session_id vm vdi n =
++  Client.Client.VBD.create ~rpc ~session_id ~vM:vm ~vDI:vdi ~userdevice:n
++    ~bootable:false ~mode:`RO ~_type:`CD ~unpluggable:true ~empty:false
++    ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[] ~device:""
++    ~currently_attached:true
++
++let with_cd_setup rpc session_id sr vm_template f =
++  print_endline (Printf.sprintf "%s: Setting up VM" __FUNCTION__) ;
++  let uuid = Client.Client.VM.get_uuid ~rpc ~session_id ~self:vm_template in
++  print_endline (Printf.sprintf "Template has uuid: %s%!" uuid) ;
++  let@ vm = Qt.VM.with_new rpc session_id ~template:vm_template ~sr in
++  print_endline (Printf.sprintf "Installed new VM") ;
++  print_endline
++    (Printf.sprintf "Using SR: %s"
++       (Client.Client.SR.get_name_label ~rpc ~session_id ~self:sr)
++    ) ;
++  let@ vdi =
++    Qt.VDI.with_new rpc session_id ~name_label:"small CD"
++      ~name_description:__LOC__
++      ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
++      sr
++  in
++  ignore (create_vbd_cd rpc session_id vm vdi "0") ;
++  let@ vdi2 =
++    Qt.VDI.with_new rpc session_id ~name_label:"small CD 2"
++      ~name_description:__LOC__
++      ~virtual_size:Int64.(mul (mul 4L 1024L) 1024L)
++      sr
++  in
++  ignore (create_vbd_cd rpc session_id vm vdi2 "1") ;
++  f rpc session_id vm vdi vdi2
++
+ let take_snapshot ?(ignore_vdis = []) rpc session_id vm ~origin =
+   Client.Client.VM.snapshot ~rpc ~session_id ~vm
+     ~new_name:(Printf.sprintf "Snapshot:%s" origin)
+@@ -86,6 +118,10 @@ let check_vdis_different expected result =
+   Alcotest.(check @@ neg vdi_ref)
+     "The VDIs after a reverting a snapshot must not be the same" expected result
+ 
++let check_vdis_same expected result =
++  Alcotest.(check vdi_ref)
++    "The VDIs after a reverting a snapshot must unchanged" expected result
++
+ let test_snapshot rpc session_id vm vdi vdi2 =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
+@@ -119,6 +155,18 @@ let test_revert rpc session_id vm vdi vdi2 =
+   check_vdis_different vdi vdi_after ;
+   check_vdis_different vdi2 vdi_after2
+ 
++let test_revert_cds rpc session_id vm vdi vdi2 =
++  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
++  Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
++
++  let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
++  let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
++  let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
++
++  (* CD VDIs are considered immutable and the clone code ignores them *)
++  check_vdis_same vdi vdi_after ;
++  check_vdis_same vdi2 vdi_after2
++
+ let a_test with_setup tests rpc session_id sr_info vm_template () =
+   let sr = sr_info.Qt.sr in
+   List.iter (with_setup rpc session_id sr vm_template) tests
+@@ -137,4 +185,6 @@ let tests () =
+         [test_snapshot; test_snapshot_ignore_vdi]
+         [`vdi_create]
+     ; suite "VM revert tests" with_setup [test_revert] [`vdi_create; `vdi_clone]
++    ; suite "VM revert with CD tests" with_cd_setup [test_revert_cds]
++        [`vdi_create; `vdi_clone]
+     ]

--- a/SOURCES/0032-xapi_vm_snapshot-Plug-out-destroying-and-cloning-dis.patch
+++ b/SOURCES/0032-xapi_vm_snapshot-Plug-out-destroying-and-cloning-dis.patch
@@ -1,0 +1,202 @@
+From eff74908e296aad4563ad8c0984f5c40c76a22a0 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 8 Oct 2025 10:46:15 +0100
+Subject: [PATCH] xapi_vm_snapshot: Plug out destroying and cloning disks into
+ a function
+
+This is preparation for using VDI.revert. No change in behaviour
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_vm_snapshot.ml | 130 ++++++++++++++++++---------------
+ 1 file changed, 70 insertions(+), 60 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index cf578baa8..743987c28 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -208,7 +208,13 @@ let safe_destroy_vusb ~__context ~rpc ~session_id vusb =
+ 
+ (* Copy the VBDs and VIFs from a source VM to a dest VM and then delete the old
+    disks. This operation destroys the data of the dest VM. *)
+-let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
++type cloned = {
++    disks: ([`VBD] Ref.t * API.ref_VDI * bool) list
++  ; cds: ([`VBD] Ref.t * API.ref_VDI * bool) list
++  ; suspend_VDI: [`VDI] Ref.t
++}
++
++let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+   let snap_VBDs = Db.VM.get_VBDs ~__context ~self:snapshot in
+   let snap_VBDs_disk, snap_VBDs_CD =
+     List.partition
+@@ -221,9 +227,8 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+   let snap_disks_snapshot_of =
+     List.map (fun vdi -> Db.VDI.get_snapshot_of ~__context ~self:vdi) snap_disks
+   in
+-  let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
+-  let snap_VGPUs = Db.VM.get_VGPUs ~__context ~self:snapshot in
+   let snap_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:snapshot in
++
+   let vm_VBDs = Db.VM.get_VBDs ~__context ~self:vm in
+   (* Filter VBDs to ensure that we don't read empty CDROMs *)
+   let vm_VBDs_disk =
+@@ -231,80 +236,85 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+       (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
+       vm_VBDs
+   in
++  (* Filter out VM disks for which the snapshot does not have a corresponding
++     disk - these disks will be left unattached after the revert is complete. *)
+   let vm_disks =
+     List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) vm_VBDs_disk
+   in
+-  (* Filter out VM disks for which the snapshot does not have a corresponding
+-     disk - these disks will be left unattached after the revert is complete. *)
+   let vm_disks_with_snapshot =
+     List.filter (fun vdi -> List.mem vdi snap_disks_snapshot_of) vm_disks
+   in
++  let vm_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:vm in
++
++  debug "Cleaning up the old VBDs and VDIs to have more free space" ;
++  List.iter (safe_destroy_vbd ~__context ~rpc ~session_id) vm_VBDs ;
++  List.iter
++    (safe_destroy_vdi ~__context ~rpc ~session_id)
++    (vm_suspend_VDI :: vm_disks_with_snapshot) ;
++  TaskHelper.set_progress ~__context 0.2 ;
++  debug "Cloning the snapshotted disks" ;
++  let driver_params = Xapi_vm_clone.make_driver_params () in
++  let cloned_disks =
++    Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
++      ~__context snap_VBDs_disk driver_params
++  in
++  let cloned_CDs =
++    Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
++      ~__context snap_VBDs_CD driver_params
++  in
++  TaskHelper.set_progress ~__context 0.5 ;
++  debug "Updating the snapshot_of fields for relevant VDIs" ;
++  List.iter2
++    (fun snap_disk (_, cloned_disk, _) ->
++      (* For each snapshot disk which was just cloned:
++         1) Find the value of snapshot_of
++         2) Find all snapshots with the same snapshot_of
++         3) Update each of these snapshots so that their snapshot_of points
++            to the new cloned disk. *)
++      let open Xapi_database.Db_filter_types in
++      let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:snap_disk in
++      let all_snaps_in_tree =
++        Db.VDI.get_refs_where ~__context
++          ~expr:(Eq (Field "snapshot_of", Literal (Ref.string_of snapshot_of)))
++      in
++      List.iter
++        (fun snapshot ->
++          Db.VDI.set_snapshot_of ~__context ~self:snapshot ~value:cloned_disk
++        )
++        all_snaps_in_tree
++    )
++    snap_disks cloned_disks ;
++  debug "Cloning the suspend VDI if needed" ;
++  let cloned_suspend_VDI =
++    if snap_suspend_VDI = Ref.null then
++      Ref.null
++    else
++      Xapi_vm_clone.clone_single_vdi rpc session_id Xapi_vm_clone.Disk_op_clone
++        ~__context snap_suspend_VDI driver_params
++  in
++  TaskHelper.set_progress ~__context 0.6 ;
++  {disks= cloned_disks; cds= cloned_CDs; suspend_VDI= cloned_suspend_VDI}
++
++let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
++  let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
++  let snap_VGPUs = Db.VM.get_VGPUs ~__context ~self:snapshot in
+   let vm_VIFs = Db.VM.get_VIFs ~__context ~self:vm in
+   let vm_VGPUs = Db.VM.get_VGPUs ~__context ~self:vm in
+-  let vm_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:vm in
+   let vm_VUSBs = Db.VM.get_VUSBs ~__context ~self:vm in
++
+   (* clone all the disks of the snapshot *)
+   Helpers.call_api_functions ~__context (fun rpc session_id ->
+-      debug "Cleaning up the old VBDs and VDIs to have more free space" ;
+-      List.iter (safe_destroy_vbd ~__context ~rpc ~session_id) vm_VBDs ;
+-      List.iter
+-        (safe_destroy_vdi ~__context ~rpc ~session_id)
+-        (vm_suspend_VDI :: vm_disks_with_snapshot) ;
+-      TaskHelper.set_progress ~__context 0.2 ;
+-      debug "Cloning the snapshotted disks" ;
+-      let driver_params = Xapi_vm_clone.make_driver_params () in
+-      let cloned_disks =
+-        Xapi_vm_clone.safe_clone_disks rpc session_id
+-          Xapi_vm_clone.Disk_op_clone ~__context snap_VBDs_disk driver_params
+-      in
+-      let cloned_CDs =
+-        Xapi_vm_clone.safe_clone_disks rpc session_id
+-          Xapi_vm_clone.Disk_op_clone ~__context snap_VBDs_CD driver_params
+-      in
+-      TaskHelper.set_progress ~__context 0.5 ;
+-      debug "Updating the snapshot_of fields for relevant VDIs" ;
+-      List.iter2
+-        (fun snap_disk (_, cloned_disk, _) ->
+-          (* For each snapshot disk which was just cloned:
+-             1) Find the value of snapshot_of
+-             2) Find all snapshots with the same snapshot_of
+-             3) Update each of these snapshots so that their snapshot_of points
+-                to the new cloned disk. *)
+-          let open Xapi_database.Db_filter_types in
+-          let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:snap_disk in
+-          let all_snaps_in_tree =
+-            Db.VDI.get_refs_where ~__context
+-              ~expr:
+-                (Eq (Field "snapshot_of", Literal (Ref.string_of snapshot_of)))
+-          in
+-          List.iter
+-            (fun snapshot ->
+-              Db.VDI.set_snapshot_of ~__context ~self:snapshot
+-                ~value:cloned_disk
+-            )
+-            all_snaps_in_tree
+-        )
+-        snap_disks cloned_disks ;
+-      debug "Cloning the suspend VDI if needed" ;
+-      let cloned_suspend_VDI =
+-        if snap_suspend_VDI = Ref.null then
+-          Ref.null
+-        else
+-          Xapi_vm_clone.clone_single_vdi rpc session_id
+-            Xapi_vm_clone.Disk_op_clone ~__context snap_suspend_VDI
+-            driver_params
+-      in
+-      TaskHelper.set_progress ~__context 0.6 ;
++      let cloned = revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm in
+       try
+         debug "Copying the VBDs" ;
+         let (_ : [`VBD] Ref.t list) =
+           List.map
+             (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
+-            (cloned_disks @ cloned_CDs)
++            (cloned.disks @ cloned.cds)
+         in
+         TaskHelper.set_progress ~__context 0.7 ;
+         debug "Update the suspend_VDI" ;
+-        Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;
++        Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned.suspend_VDI ;
+         debug "Cleaning up the old VIFs" ;
+         List.iter (safe_destroy_vif ~__context ~rpc ~session_id) vm_VIFs ;
+         debug "Setting up the new VIFs" ;
+@@ -332,7 +342,7 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+           "Error while updating the new VBD, VDI, VIF and VGPU records. \
+            Cleaning up the cloned VDIs." ;
+         let vdis =
+-          cloned_suspend_VDI
++          cloned.suspend_VDI
+           :: List.fold_left
+                (fun acc (_, vdi, on_error_delete) ->
+                  if on_error_delete then
+@@ -340,7 +350,7 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+                  else
+                    acc
+                )
+-               [] cloned_disks
++               [] cloned.disks
+         in
+         List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis ;
+         raise e

--- a/SOURCES/0033-xapi_vm_snapshot-move-VDI-related-DB-operations-insi.patch
+++ b/SOURCES/0033-xapi_vm_snapshot-move-VDI-related-DB-operations-insi.patch
@@ -1,0 +1,90 @@
+From 6dfcc0e2f98aeac5bf2f76f1bfc8ddec11b826b2 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 8 Oct 2025 15:14:57 +0100
+Subject: [PATCH] xapi_vm_snapshot: move VDI-related DB operations inside
+ revert_vbds
+
+This moves them outside of the try catch that destroys newly-cloned
+disks, but this is safe since these don't change the state of the host
+like the destroy vifs.
+
+This allows to simplify the type needed to be able to clean up the new
+VDIs in case of failure.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_vm_snapshot.ml | 46 +++++++++++++++++-----------------
+ 1 file changed, 23 insertions(+), 23 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index 743987c28..a4b491877 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -293,7 +293,24 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+         ~__context snap_suspend_VDI driver_params
+   in
+   TaskHelper.set_progress ~__context 0.6 ;
+-  {disks= cloned_disks; cds= cloned_CDs; suspend_VDI= cloned_suspend_VDI}
++  debug "Copying the VBDs" ;
++  let (_ : [`VBD] Ref.t list) =
++    List.map
++      (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
++      (cloned_disks @ cloned_CDs)
++  in
++  debug "Update the suspend_VDI" ;
++  Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;
++
++  cloned_suspend_VDI
++  :: List.fold_left
++       (fun acc (_, vdi, on_error_delete) ->
++         if on_error_delete then
++           vdi :: acc
++         else
++           acc
++       )
++       [] cloned_disks
+ 
+ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+   let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
+@@ -304,17 +321,11 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+ 
+   (* clone all the disks of the snapshot *)
+   Helpers.call_api_functions ~__context (fun rpc session_id ->
+-      let cloned = revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm in
++      let vdis_to_cleanup =
++        revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm
++      in
++      TaskHelper.set_progress ~__context 0.7 ;
+       try
+-        debug "Copying the VBDs" ;
+-        let (_ : [`VBD] Ref.t list) =
+-          List.map
+-            (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
+-            (cloned.disks @ cloned.cds)
+-        in
+-        TaskHelper.set_progress ~__context 0.7 ;
+-        debug "Update the suspend_VDI" ;
+-        Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned.suspend_VDI ;
+         debug "Cleaning up the old VIFs" ;
+         List.iter (safe_destroy_vif ~__context ~rpc ~session_id) vm_VIFs ;
+         debug "Setting up the new VIFs" ;
+@@ -341,18 +352,7 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+         error
+           "Error while updating the new VBD, VDI, VIF and VGPU records. \
+            Cleaning up the cloned VDIs." ;
+-        let vdis =
+-          cloned.suspend_VDI
+-          :: List.fold_left
+-               (fun acc (_, vdi, on_error_delete) ->
+-                 if on_error_delete then
+-                   vdi :: acc
+-                 else
+-                   acc
+-               )
+-               [] cloned.disks
+-        in
+-        List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis ;
++        List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis_to_cleanup ;
+         raise e
+   )
+ 

--- a/SOURCES/0034-xapi_vm_snapshot-cover-more-code-to-destroy-newly-cl.patch
+++ b/SOURCES/0034-xapi_vm_snapshot-cover-more-code-to-destroy-newly-cl.patch
@@ -1,0 +1,117 @@
+From 0bdac2cd4d2bab9b983a6a6dadd7b9b440bd1d32 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 8 Oct 2025 17:03:56 +0100
+Subject: [PATCH] xapi_vm_snapshot: cover more code to destroy newly cloned
+ VDIs
+
+Previously in some parts of the revert, (rare) failures would not induce
+the deletion of newly cloned VDIs.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_vm_snapshot.ml | 57 +++++++++++++++++++++-------------
+ 1 file changed, 35 insertions(+), 22 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index a4b491877..19c8a55f1 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -206,6 +206,10 @@ let safe_destroy_vusb ~__context ~rpc ~session_id vusb =
+   if Db.is_valid_ref __context vusb then
+     Client.VUSB.destroy ~rpc ~session_id ~self:vusb
+ 
++let with_vdis_on_error ~vdis f = try f () with e -> Error (e, vdis)
++
++let ( let@ ) f x = f x
++
+ (* Copy the VBDs and VIFs from a source VM to a dest VM and then delete the old
+    disks. This operation destroys the data of the dest VM. *)
+ type cloned = {
+@@ -258,6 +262,17 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+     Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
+       ~__context snap_VBDs_disk driver_params
+   in
++  let destroy_vdis_on_error =
++    List.filter_map
++      (fun (_, vdi, on_error_delete) ->
++        if on_error_delete then
++          Some vdi
++        else
++          None
++      )
++      cloned_disks
++  in
++  let@ () = with_vdis_on_error ~vdis:destroy_vdis_on_error in
+   let cloned_CDs =
+     Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
+       ~__context snap_VBDs_CD driver_params
+@@ -292,6 +307,8 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+       Xapi_vm_clone.clone_single_vdi rpc session_id Xapi_vm_clone.Disk_op_clone
+         ~__context snap_suspend_VDI driver_params
+   in
++  let destroy_vdis_on_error = cloned_suspend_VDI :: destroy_vdis_on_error in
++  let@ () = with_vdis_on_error ~vdis:destroy_vdis_on_error in
+   TaskHelper.set_progress ~__context 0.6 ;
+   debug "Copying the VBDs" ;
+   let (_ : [`VBD] Ref.t list) =
+@@ -301,16 +318,7 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+   in
+   debug "Update the suspend_VDI" ;
+   Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;
+-
+-  cloned_suspend_VDI
+-  :: List.fold_left
+-       (fun acc (_, vdi, on_error_delete) ->
+-         if on_error_delete then
+-           vdi :: acc
+-         else
+-           acc
+-       )
+-       [] cloned_disks
++  Ok destroy_vdis_on_error
+ 
+ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+   let snap_VIFs = Db.VM.get_VIFs ~__context ~self:snapshot in
+@@ -321,11 +329,11 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+ 
+   (* clone all the disks of the snapshot *)
+   Helpers.call_api_functions ~__context (fun rpc session_id ->
+-      let vdis_to_cleanup =
+-        revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm
+-      in
+-      TaskHelper.set_progress ~__context 0.7 ;
+-      try
++      let ( let* ) = Result.bind in
++      let destroy_error_vdis =
++        let* new_vdis = revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm in
++        let@ () = with_vdis_on_error ~vdis:new_vdis in
++        TaskHelper.set_progress ~__context 0.7 ;
+         debug "Cleaning up the old VIFs" ;
+         List.iter (safe_destroy_vif ~__context ~rpc ~session_id) vm_VIFs ;
+         debug "Setting up the new VIFs" ;
+@@ -347,13 +355,18 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+         let (_ : [`VGPU] Ref.t list) =
+           List.map (fun vgpu -> Xapi_vgpu.copy ~__context ~vm vgpu) snap_VGPUs
+         in
+-        TaskHelper.set_progress ~__context 0.9
+-      with e ->
+-        error
+-          "Error while updating the new VBD, VDI, VIF and VGPU records. \
+-           Cleaning up the cloned VDIs." ;
+-        List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis_to_cleanup ;
+-        raise e
++        TaskHelper.set_progress ~__context 0.9 ;
++        Ok ()
++      in
++      match destroy_error_vdis with
++      | Ok () ->
++          ()
++      | Error (e, vdis) ->
++          error
++            "Error while updating the new VBD, VDI, VIF and VGPU records. \
++             Cleaning up the cloned VDIs." ;
++          List.iter (safe_destroy_vdi ~__context ~rpc ~session_id) vdis ;
++          raise e
+   )
+ 
+ let update_guest_metrics ~__context ~vm ~snapshot =

--- a/SOURCES/0035-xapi_vm_snapshot-shorten-length-of-comments.patch
+++ b/SOURCES/0035-xapi_vm_snapshot-shorten-length-of-comments.patch
@@ -1,0 +1,98 @@
+From c888ad3ea7fb0c223cf0463fbdc34fd6f410364c Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 5 Jun 2026 10:22:35 +0100
+Subject: [PATCH] xapi_vm_snapshot: shorten length of comments
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/xapi_vm_snapshot.ml | 36 ++++++++++++++++++----------------
+ 1 file changed, 19 insertions(+), 17 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index 19c8a55f1..3392c34c9 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -23,9 +23,9 @@ module D = Debug.Make (struct let name = "xapi_vm_snapshot" end)
+ module Xs = Ezxenstore_core.Xenstore
+ open D
+ 
+-(*************************************************************************************************)
+-(* Crash-consistant snapshot                                                                     *)
+-(*************************************************************************************************)
++(******************************************************************************)
++(* Crash-consistant snapshot                                                  *)
++(******************************************************************************)
+ let snapshot ~__context ~vm ~new_name ~ignore_vdis =
+   debug "Snapshot: begin" ;
+   TaskHelper.set_cancellable ~__context ;
+@@ -36,9 +36,9 @@ let snapshot ~__context ~vm ~new_name ~ignore_vdis =
+   in
+   debug "Snapshot: end" ; res
+ 
+-(*************************************************************************************************)
+-(* Quiesced snapshot                                                                             *)
+-(*************************************************************************************************)
++(******************************************************************************)
++(* Quiesced snapshot                                                          *)
++(******************************************************************************)
+ (* xenstore paths *)
+ let control_path ~xs ~domid x = xs.Xs.getdomainpath domid ^ "/control/" ^ x
+ 
+@@ -48,10 +48,12 @@ let snapshot_path ~xs ~domid x =
+ let snapshot_cleanup_path ~xs ~domid =
+   xs.Xs.getdomainpath domid ^ "/control/snapshot"
+ 
+-(* check if [flag] is set in the control_path of the VM [vm]. This looks like this code is a kind  *)
+-(* of duplicate of the one in {!xal.ml}, {!events.ml} and {!xapi_guest_agent.ml} which are looking *)
+-(* dynamically if there is a change in this part of the VM's xenstore tree. However, at the moment *)
+-(* always allowing the operation and checking if it is enabled when it is triggered is sufficient. *)
++(* check if [flag] is set in the control_path of the VM [vm]. This looks like
++   this code is a kind of duplicate of the one in {!xal.ml}, {!events.ml} and
++   {!xapi_guest_agent.ml} which are looking dynamically if there is a change in
++   this part of the VM's xenstore tree. However, at the moment always allowing
++   the operation and checking if it is enabled when it is triggered is
++   sufficient. *)
+ let is_flag_set ~xs ~flag ~domid ~vm =
+   try xs.Xs.read (control_path ~xs ~domid flag) = "1"
+   with e ->
+@@ -59,17 +61,17 @@ let is_flag_set ~xs ~flag ~domid ~vm =
+       (Ref.string_of vm) domid (Printexc.to_string e) ;
+     false
+ 
+-(* we want to compare the integer at the end of a common string, ie. strings as x="/local/..../3" *)
+-(* and y="/local/.../12". The result should be x < y.                                             *)
++(* we want to compare the integer at the end of a common string, ie. strings as
++   x="/local/..../3" and y="/local/.../12". The result should be x < y. *)
+ let compare_snapid_chunks s1 s2 =
+   if String.length s1 <> String.length s2 then
+     String.length s1 - String.length s2
+   else
+     compare s1 s2
+ 
+-(*************************************************************************************************)
+-(* Checkpoint                                                                                    *)
+-(*************************************************************************************************)
++(******************************************************************************)
++(* Checkpoint                                                                 *)
++(******************************************************************************)
+ let checkpoint ~__context ~vm ~new_name =
+   Xapi_vmss.show_task_in_xencenter ~__context ~vm ;
+   let power_state = Db.VM.get_power_state ~__context ~self:vm in
+@@ -120,7 +122,6 @@ let checkpoint ~__context ~vm ~new_name =
+         Xapi_gpumon.update_vgpu_metadata ~__context ~vm ;
+         Xapi_xenops.suspend ~__context ~self:vm
+       with Api_errors.Server_error (_, _) as e -> raise e
+-    (* | _ -> raise (Api_errors.Server_error (Api_errors.vm_checkpoint_suspend_failed, [Ref.string_of vm])) *)
+   ) ;
+   (* snapshot the disks and the suspend VDI *)
+   let snap, err =
+@@ -347,7 +348,8 @@ let update_vifs_vbds_vgpus_and_vusbs ~__context ~snapshot ~vm =
+         in
+         TaskHelper.set_progress ~__context 0.8 ;
+         debug "Cleaning up the old VUSBs" ;
+-        (* As snapshot is not allowed when vm has VUSBs, so no need to set up new VUSBs.*)
++        (* As snapshot is not allowed when vm has VUSBs, so no need to set up
++           new VUSBs.*)
+         List.iter (safe_destroy_vusb ~__context ~rpc ~session_id) vm_VUSBs ;
+         debug "Cleaning up the old VGPUs" ;
+         List.iter (safe_destroy_vgpu ~__context ~rpc ~session_id) vm_VGPUs ;

--- a/SOURCES/0036-xapi_vdi-Introduce-VDI-operations-needed-for-revert.patch
+++ b/SOURCES/0036-xapi_vdi-Introduce-VDI-operations-needed-for-revert.patch
@@ -1,0 +1,235 @@
+From 8f716fb6fb693587d1712d5bf86e04e8426d04b4 Mon Sep 17 00:00:00 2001
+From: John Else <john.else@citrix.com>
+Date: Tue, 9 Sep 2014 12:31:03 +0100
+Subject: [PATCH] xapi_vdi: Introduce VDI operations needed for revert
+
+This is for both the live VDI (revert_from) and the snapshot (revert_to)
+
+These correspond to the VM operations `reverting` and `revert`,
+respectively.
+
+Only snapshots backed by an SR that allows clones are allowed to be
+reverted to. This is because SRs supporting revert is not enough to use
+vdi revert without clone: having an incorrect snapshot_of field will
+also cause the use of clone. With this we can ensure that if a bad edge
+case is met the system has a working fallback.
+
+Reverting to "live" snapshot VDIs is allowed, this happens when
+reverting to a checkpoint.
+
+Currently reverting requires the cloning feature because it's not
+possible to discriminate between backends that support vdi revert and
+ones that done. This will be possible once all of them do
+
+Test that VDIs...
+* can be reverted to a snapshot.
+* can be reverted to an attached snapshot.
+* cannot be reverted to a leaf VDI.
+* cannot be reverted to an attached leaf.
+
+Co-authored-by: John Else <john.else@citrix.com>
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/idl/datamodel.ml                      |  2 +
+ ocaml/idl/schematest.ml                     |  2 +-
+ ocaml/tests/record_util/old_record_util.ml  |  4 ++
+ ocaml/tests/test_vdi_allowed_operations.ml  | 49 +++++++++++++++++++++
+ ocaml/tests/test_vdi_allowed_operations.mli |  1 +
+ ocaml/xapi/xapi_vdi.ml                      | 29 +++++++++---
+ 6 files changed, 79 insertions(+), 8 deletions(-)
+ create mode 100644 ocaml/tests/test_vdi_allowed_operations.mli
+
+diff --git a/ocaml/idl/datamodel.ml b/ocaml/idl/datamodel.ml
+index 4e4a00a6b..16bd65622 100644
+--- a/ocaml/idl/datamodel.ml
++++ b/ocaml/idl/datamodel.ml
+@@ -5689,6 +5689,8 @@ module VDI = struct
+           )
+         ; ("set_on_boot", "Setting the on_boot field of the VDI")
+         ; ("blocked", "Operations on this VDI are temporarily blocked")
++        ; ("revert_to", "Reverting a VDI to a clone of this snapshot")
++        ; ("revert_from", "Reverting this VDI to a clone of a snapshot")
+         ]
+       )
+ 
+diff --git a/ocaml/idl/schematest.ml b/ocaml/idl/schematest.ml
+index a90bf8687..0d75d41d0 100644
+--- a/ocaml/idl/schematest.ml
++++ b/ocaml/idl/schematest.ml
+@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
+ (* BEWARE: if this changes, check that schema has been bumped accordingly in
+    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
+ 
+-let last_known_schema_hash = "88b40556fd6a45af918900ff6d8079c5"
++let last_known_schema_hash = "f828a19597e924bede4f41b98c166795"
+ 
+ let current_schema_hash : string =
+   let open Datamodel_types in
+diff --git a/ocaml/tests/record_util/old_record_util.ml b/ocaml/tests/record_util/old_record_util.ml
+index 855a2b74b..ba01a52d3 100644
+--- a/ocaml/tests/record_util/old_record_util.ml
++++ b/ocaml/tests/record_util/old_record_util.ml
+@@ -299,6 +299,10 @@ let vdi_operation_to_string : API.vdi_operations -> string = function
+       "set_on_boot"
+   | `blocked ->
+       "blocked"
++  | `revert_to ->
++      "revert_to"
++  | `revert_from ->
++      "revert_from"
+ 
+ let sr_operation_to_string : API.storage_operations -> string = function
+   | `scan ->
+diff --git a/ocaml/tests/test_vdi_allowed_operations.ml b/ocaml/tests/test_vdi_allowed_operations.ml
+index 877b4fa48..001774202 100644
+--- a/ocaml/tests/test_vdi_allowed_operations.ml
++++ b/ocaml/tests/test_vdi_allowed_operations.ml
+@@ -573,6 +573,54 @@ let test_update_allowed_operations () =
+   Alcotest.(check Alcotest_comparators.vdi_operations_set)
+     "update_allowed_operations should be correct" ok_ops allowed_operations
+ 
++(* Tests for revert operation *)
++let test_revert =
++  let test_can_revert_to_snapshot () =
++    let __context = Mock.make_context_with_new_db "Mock context" in
++
++    run_assert_equal_with_vdi ~__context
++      ~vdi_fun:(fun vdi_ref ->
++        Db.VDI.set_is_a_snapshot ~__context ~self:vdi_ref ~value:true
++      )
++      `revert_to (Ok ())
++  in
++  (* VBDs of checkpoints are marked with currently_attached = true, but we still
++     need to be able to revert to them. *)
++  let test_can_revert_to_checkpoint () =
++    let __context = Mock.make_context_with_new_db "Mock context" in
++
++    run_assert_equal_with_vdi ~__context
++      ~vdi_fun:(fun vdi_ref ->
++        Db.VDI.set_is_a_snapshot ~__context ~self:vdi_ref ~value:true ;
++        make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RW ()
++      )
++      `revert_to (Ok ())
++  in
++  let test_cannot_revert_to_leaf () =
++    let __context = Mock.make_context_with_new_db "Mock context" in
++
++    run_assert_equal_with_vdi ~__context
++      ~vdi_fun:(fun _ -> ())
++      `revert_to
++      (Error (Api_errors.only_revert_snapshot, []))
++  in
++  let test_cannot_revert_live () =
++    let __context = Mock.make_context_with_new_db "Mock context" in
++
++    run_assert_equal_with_vdi ~__context
++      ~vdi_fun:(fun vdi_ref ->
++        make_vbd ~__context ~vDI:vdi_ref ~currently_attached:true ~mode:`RW ()
++      )
++      `revert_from
++      (Error (Api_errors.vdi_in_use, []))
++  in
++  [
++    ("Revert: Can revert to snapshot", `Quick, test_can_revert_to_snapshot)
++  ; ("Revert: Can revert to checkpoint", `Quick, test_can_revert_to_checkpoint)
++  ; ("Revert: Cannot revert to leaf", `Quick, test_cannot_revert_to_leaf)
++  ; ("Revert: Cannot revert live", `Quick, test_cannot_revert_live)
++  ]
++
+ let test =
+   [
+     ("test_ca98944", `Quick, test_ca98944)
+@@ -586,3 +634,4 @@ let test =
+       ("test_null_vm", `Quick, test_null_vm)
+     ; ("test_update_allowed_operations", `Quick, test_update_allowed_operations)
+     ]
++  @ test_revert
+diff --git a/ocaml/tests/test_vdi_allowed_operations.mli b/ocaml/tests/test_vdi_allowed_operations.mli
+new file mode 100644
+index 000000000..dd02dd1f7
+--- /dev/null
++++ b/ocaml/tests/test_vdi_allowed_operations.mli
+@@ -0,0 +1 @@
++val test : (string * [> `Quick] * (unit -> unit)) list
+diff --git a/ocaml/xapi/xapi_vdi.ml b/ocaml/xapi/xapi_vdi.ml
+index 7ce251f08..a847093bb 100644
+--- a/ocaml/xapi/xapi_vdi.ml
++++ b/ocaml/xapi/xapi_vdi.ml
+@@ -39,7 +39,7 @@ let feature_of_op =
+       Some Vdi_resize_online
+   | `generate_config ->
+       Some Vdi_generate_config
+-  | `clone ->
++  | `clone | `revert_to | `revert_from ->
+       Some Vdi_clone
+   | `mirror ->
+       Some Vdi_mirror
+@@ -210,11 +210,16 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
+     (* check to see whether VBDs exist which are using this VDI *)
+ 
+     (* If the VBD is currently_attached then some operations can still be
+-       performed ie: VDI.clone (if the VM is suspended we have to have the
+-        'allow_clone_suspended_vm' flag); VDI.snapshot; VDI.resize_online;
+-        'blocked' (CP-831); VDI.data_destroy: it is not allowed on VDIs linked
+-        to a VM, but the implementation first waits for the VDI's VBDs to be
+-        unplugged and destroyed, and the checks are performed there.
++       performed ie:
++       - VDI.clone (if the VM is suspended we have to have the
++         'allow_clone_suspended_vm' flag)
++       - VDI.snapshot
++       - VDI.resize_online
++       - VDI.blocked (CP-831)
++       - VDI.data_destroy: it is not allowed on VDIs linked to a VM, but the
++         implementation first waits for the VDI's VBDs to be unplugged and
++         destroyed, and the checks are performed there
++       - VDI.revert: is allowed as checkpoints have currently_attached VBDs
+     *)
+     let operation_can_be_performed_live =
+       match op with
+@@ -222,6 +227,7 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
+       | `resize_online
+       | `blocked
+       | `clone
++      | `revert_to
+       | `mirror
+       | `enable_cbt
+       | `disable_cbt
+@@ -305,6 +311,8 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
+       | `resize
+       | `resize_online
+       | `snapshot
++      | `revert_to
++      | `revert_from
+       | `set_on_boot ->
+           false
+       | `blocked
+@@ -347,6 +355,8 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
+       | `resize
+       | `resize_online
+       | `snapshot
++      | `revert_to
++      | `revert_from
+       | `update ->
+           true
+     in
+@@ -387,7 +397,7 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
+           Error (Api_errors.vdi_has_rrds, [_ref])
+         else
+           Ok ()
+-    | `destroy ->
++    | `destroy | `revert_from ->
+         check_destroy ()
+     | `data_destroy ->
+         if not record.Db_actions.vDI_is_a_snapshot then
+@@ -445,6 +455,11 @@ let check_operation_error ~__context ?sr_records:_ ?(pbd_records = [])
+           Error (Api_errors.vdi_on_boot_mode_incompatible_with_operation, [])
+         else
+           Ok ()
++    | `revert_to ->
++        if not record.Db_actions.vDI_is_a_snapshot then
++          Error (Api_errors.only_revert_snapshot, [])
++        else
++          Ok ()
+     | `mirror
+     | `clone
+     | `generate_config

--- a/SOURCES/0037-storage-add-VDI.revert.patch
+++ b/SOURCES/0037-storage-add-VDI.revert.patch
@@ -1,0 +1,287 @@
+From 25e82977eb9243b4a7f5ede2cf6ba4e8389c168d Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 24 Sep 2025 10:27:37 +0100
+Subject: [PATCH] storage: add VDI.revert
+
+This operation allows storage backends to implement VDI revert natively,
+as well as advertise it. The operation is unused by xapi for the time
+being.
+
+Signed-off-by: David Scott <dave.scott@eu.citrix.com>
+Signed-off-by: John Else <john.else@citrix.com>
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi-idl/storage/storage_interface.ml   | 15 +++++++++++++
+ ocaml/xapi-idl/storage/storage_skeleton.ml    |  3 +++
+ ocaml/xapi-storage-script/main.ml             | 18 ++++++++++++++--
+ ocaml/xapi-storage/generator/lib/control.ml   | 21 +++++++++++++++++++
+ .../generator/test/storage_test.ml            |  1 +
+ ocaml/xapi/sm.ml                              | 12 +++++++++++
+ ocaml/xapi/smint.ml                           |  2 ++
+ ocaml/xapi/storage_mux.ml                     |  9 ++++++++
+ ocaml/xapi/storage_smapiv1.ml                 | 15 +++++++++++++
+ ocaml/xapi/storage_smapiv1_wrapper.ml         |  7 +++++++
+ 10 files changed, 101 insertions(+), 2 deletions(-)
+
+diff --git a/ocaml/xapi-idl/storage/storage_interface.ml b/ocaml/xapi-idl/storage/storage_interface.ml
+index d47123e2b..3f897ebfe 100644
+--- a/ocaml/xapi-idl/storage/storage_interface.ml
++++ b/ocaml/xapi-idl/storage/storage_interface.ml
+@@ -1023,6 +1023,15 @@ module StorageAPI (R : RPC) = struct
+       let result_p = Param.mk ~name:"changed_blocks" Types.string in
+       declare "VDI.list_changed_blocks" []
+         (dbg_p @-> sr_p @-> vdi_from_p @-> vdi_to_p @-> returning result_p err)
++
++    (** [revert dbg sr snapshot_info] creates a new VDI which is a clone of
++        [snapshot_info] in [sr]. The contents of the VDI in
++        [snapshot_info.snapshot_of] will be destroyed and replaced with the
++        contents of [snapshot] *)
++    let revert =
++      let snapshot_info_p = Param.mk ~name:"snapshot_info" vdi_info in
++      declare "VDI.revert" []
++        (dbg_p @-> sr_p @-> snapshot_info_p @-> returning unit_p err)
+   end
+ 
+   (** [get_by_name task name] returns a vdi with [name] (which may be in any SR) *)
+@@ -1635,6 +1644,9 @@ module type Server_impl = sig
+ 
+     val list_changed_blocks :
+       context -> dbg:debug_info -> sr:sr -> vdi_from:vdi -> vdi_to:vdi -> string
++
++    val revert :
++      context -> dbg:debug_info -> sr:sr -> snapshot_info:vdi_info -> unit
+   end
+ 
+   val get_by_name : context -> dbg:debug_info -> name:string -> sr * vdi_info
+@@ -1837,6 +1849,9 @@ module Server (Impl : Server_impl) () = struct
+     S.VDI.list_changed_blocks (fun dbg sr vdi_from vdi_to ->
+         Impl.VDI.list_changed_blocks () ~dbg ~sr ~vdi_from ~vdi_to
+     ) ;
++    S.VDI.revert (fun dbg sr snapshot_info ->
++        Impl.VDI.revert () ~dbg ~sr ~snapshot_info
++    ) ;
+     S.get_by_name (fun dbg name -> Impl.get_by_name () ~dbg ~name) ;
+     S.DATA.copy (fun dbg sr vdi vm url dest verify_dest ->
+         Impl.DATA.copy () ~dbg ~sr ~vdi ~vm ~url ~dest ~verify_dest
+diff --git a/ocaml/xapi-idl/storage/storage_skeleton.ml b/ocaml/xapi-idl/storage/storage_skeleton.ml
+index a2d2d04ab..404708f97 100644
+--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
++++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
+@@ -175,6 +175,9 @@ module VDI = struct
+ 
+   let list_changed_blocks ctx ~dbg ~sr ~vdi_from ~vdi_to =
+     Storage_interface.unimplemented __FUNCTION__
++
++  let revert ctx ~dbg ~sr ~snapshot_info =
++    Storage_interface.unimplemented __FUNCTION__
+ end
+ 
+ let get_by_name ctx ~dbg ~name = Storage_interface.unimplemented __FUNCTION__
+diff --git a/ocaml/xapi-storage-script/main.ml b/ocaml/xapi-storage-script/main.ml
+index 34372986c..5f2ec1713 100644
+--- a/ocaml/xapi-storage-script/main.ml
++++ b/ocaml/xapi-storage-script/main.ml
+@@ -1352,6 +1352,8 @@ module VDIImpl (M : META) = struct
+           dbg sr vdi
+     )
+ 
++  let ( let* ) = Lwt_result.bind
++
+   let update_keys ~dbg ~sr ~key ~value response =
+     match value with
+     | None ->
+@@ -1371,6 +1373,11 @@ module VDIImpl (M : META) = struct
+         Volume_client.destroy (volume_rpc ~dbg) dbg sr vdi
+     )
+ 
++  let revert ~dbg ~sr ~snapshot ~vdi =
++    return_volume_rpc (fun () ->
++        Volume_client.revert (volume_rpc ~dbg) dbg sr snapshot vdi
++    )
++
+   let vdi_attach_common dbg sr vdi domain =
+     Attached_SRs.find sr >>>= fun sr ->
+     (* Discover the URIs using Volume.stat *)
+@@ -1421,6 +1428,14 @@ module VDIImpl (M : META) = struct
+     )
+     |> wrap
+ 
++  let revert_impl dbg sr snapshot_info =
++    wrap
++    @@
++    let snapshot = Storage_interface.(Vdi.string_of snapshot_info.vdi) in
++    let vdi = Storage_interface.(Vdi.string_of snapshot_info.snapshot_of) in
++    let* sr = Attached_SRs.find sr in
++    revert ~dbg ~sr ~snapshot ~vdi
++
+   let vdi_snapshot_impl dbg sr vdi_info =
+     Attached_SRs.find sr
+     >>>= (fun sr ->
+@@ -1659,8 +1674,6 @@ module VDIImpl (M : META) = struct
+ 
+   let vdi_set_persistent_impl _dbg _sr _vdi _persistent = return () |> wrap
+ 
+-  let ( let* ) = Lwt_result.bind
+-
+   let vdi_enable_cbt_impl dbg sr vdi =
+     wrap
+     @@
+@@ -1946,6 +1959,7 @@ let bind ~volume_script_dir =
+   S.VDI.add_to_sm_config VDI.vdi_add_to_sm_config_impl ;
+   S.VDI.remove_from_sm_config VDI.vdi_remove_from_sm_config_impl ;
+   S.VDI.similar_content VDI.similar_content_impl ;
++  S.VDI.revert VDI.revert_impl ;
+ 
+   let module DP = DPImpl (RuntimeMeta) in
+   S.DP.destroy2 DP.dp_destroy2 ;
+diff --git a/ocaml/xapi-storage/generator/lib/control.ml b/ocaml/xapi-storage/generator/lib/control.ml
+index e7f9274c4..29acd2add 100644
+--- a/ocaml/xapi-storage/generator/lib/control.ml
++++ b/ocaml/xapi-storage/generator/lib/control.ml
+@@ -276,6 +276,27 @@ module Volume (R : RPC) = struct
+       ["[destroy sr volume] removes [volume] from [sr]"]
+       (dbg @-> sr @-> key @-> returning unit errors)
+ 
++  let revert =
++    let snapshot_p =
++      Param.
++        {
++          key with
++          name= Some "snapshot"
++        ; description=
++            [
++              "Read-only volume with the contents that are to be present in \
++               the resulting volume"
++            ]
++        }
++    in
++    R.declare "revert"
++      [
++        "[revert sr snapshot volume] returns a reference to a volume. This "
++      ; "volume must contain the contents of the read-only [snapshot], and its "
++      ; "identity must remain the same as [volume]."
++      ]
++      (dbg @-> sr @-> snapshot_p @-> key @-> returning unit errors)
++
+   let new_name =
+     Param.mk ~name:"new_name" ~description:["New name"] Types.string
+ 
+diff --git a/ocaml/xapi-storage/generator/test/storage_test.ml b/ocaml/xapi-storage/generator/test/storage_test.ml
+index 3da8be647..563d5aa9c 100644
+--- a/ocaml/xapi-storage/generator/test/storage_test.ml
++++ b/ocaml/xapi-storage/generator/test/storage_test.ml
+@@ -189,6 +189,7 @@ let volume_server () =
+   Volume.data_destroy unimplemented ;
+   Volume.list_changed_blocks unimplemented ;
+   Volume.compose unimplemented ;
++  Volume.revert unimplemented ;
+ 
+   Idl.Exn.server Volume.implementation
+ 
+diff --git a/ocaml/xapi/sm.ml b/ocaml/xapi/sm.ml
+index 1d198cf3f..d70173865 100644
+--- a/ocaml/xapi/sm.ml
++++ b/ocaml/xapi/sm.ml
+@@ -270,6 +270,18 @@ let vdi_snapshot ~dbg dconf driver driver_params sr vdi =
+   in
+   Sm_exec.parse_vdi_info (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
+ 
++let vdi_revert ~dbg dconf driver sr vdi snapshot =
++  debug "vdi_revert" driver
++    (sprintf "sr=%s vdi=%s snapshot=%s" (Ref.string_of sr) (Ref.string_of vdi)
++       (Ref.string_of snapshot)
++    ) ;
++  (* NB the SM backends treat the snapshot as the 'target', hence first argument *)
++  let call =
++    Sm_exec.make_call ~sr_ref:sr ~vdi_ref:snapshot dconf "vdi_revert"
++      [Ref.string_of vdi]
++  in
++  Sm_exec.parse_unit (Sm_exec.exec_xmlrpc ~dbg (driver_filename driver) call)
++
+ let vdi_clone ~dbg dconf driver driver_params sr vdi =
+   with_dbg ~dbg ~name:"vdi_clone" @@ fun di ->
+   let dbg = Debug_info.to_string di in
+diff --git a/ocaml/xapi/smint.ml b/ocaml/xapi/smint.ml
+index 1b4e4d45e..893a0bb72 100644
+--- a/ocaml/xapi/smint.ml
++++ b/ocaml/xapi/smint.ml
+@@ -60,6 +60,7 @@ module Feature = struct
+     | Large_vdi  (** Supports >2TB VDIs *)
+     | Thin_provisioning
+     | Vdi_read_caching
++    | Vdi_revert
+ 
+   type t = capability * int64
+ 
+@@ -101,6 +102,7 @@ module Feature = struct
+     ; ("LARGE_VDI", Large_vdi)
+     ; ("THIN_PROVISIONING", Thin_provisioning)
+     ; ("VDI_READ_CACHING", Vdi_read_caching)
++    ; ("VDI_REVERT", Vdi_revert)
+     ]
+ 
+   let capability_to_string_table =
+diff --git a/ocaml/xapi/storage_mux.ml b/ocaml/xapi/storage_mux.ml
+index c2a0b7f32..6b3a0c89a 100644
+--- a/ocaml/xapi/storage_mux.ml
++++ b/ocaml/xapi/storage_mux.ml
+@@ -780,6 +780,15 @@ module Mux = struct
+         let rpc = of_sr sr
+       end)) in
+       C.VDI.list_changed_blocks (Debug_info.to_string di) sr vdi_from vdi_to
++
++    let revert () ~dbg ~sr ~snapshot_info =
++      with_dbg ~name:"VDI.revert" ~dbg @@ fun di ->
++      info "VDI.revert dbg:%s sr:%s snapshot:%s" dbg (s_of_sr sr)
++        (string_of_vdi_info snapshot_info) ;
++      let module C = StorageAPI (Idl.Exn.GenClient (struct
++        let rpc = of_sr sr
++      end)) in
++      C.VDI.revert (Debug_info.to_string di) sr snapshot_info
+   end
+ 
+   let get_by_name () ~dbg ~name =
+diff --git a/ocaml/xapi/storage_smapiv1.ml b/ocaml/xapi/storage_smapiv1.ml
+index dc1a48e80..3d39cf320 100644
+--- a/ocaml/xapi/storage_smapiv1.ml
++++ b/ocaml/xapi/storage_smapiv1.ml
+@@ -1124,6 +1124,21 @@ module SMAPIv1 : Server_impl = struct
+           raise (Storage_error (Backend_error (code, params)))
+       | Sm.MasterOnly ->
+           redirect sr
++
++    let call_revert ~__context ~dbg ~sr ~snapshot_info =
++      let snap = find_vdi ~__context sr snapshot_info.vdi |> fst in
++      for_vdi ~dbg ~sr ~vdi:snapshot_info.snapshot_of "VDI.revert"
++        (fun device_config _type sr self ->
++          Sm.vdi_revert ~dbg device_config _type sr self snap
++      )
++
++    let revert _context ~dbg ~sr ~snapshot_info =
++      with_dbg ~name:"VDI.revert" ~dbg @@ fun di ->
++      let dbg = Debug_info.to_string di in
++      Server_helpers.exec_with_new_task "VDI.revert"
++        ~subtask_of:(Ref.of_string dbg) (fun __context ->
++          call_revert ~__context ~dbg ~sr ~snapshot_info
++      )
+   end
+ 
+   let get_by_name _context ~dbg:_ ~name:_ = assert false
+diff --git a/ocaml/xapi/storage_smapiv1_wrapper.ml b/ocaml/xapi/storage_smapiv1_wrapper.ml
+index 71e11367b..21e02be85 100644
+--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
++++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
+@@ -843,6 +843,13 @@ functor
+       let data_destroy =
+         destroy_and_data_destroy "VDI.data_destroy" Impl.VDI.data_destroy
+ 
++      let revert context ~dbg ~sr ~snapshot_info =
++        with_dbg ~name:"VDI.revert" ~dbg @@ fun di ->
++        info "VDI.revert dbg:%s sr:%s snapshot:%s" di.log (s_of_sr sr)
++          (string_of_vdi_info snapshot_info) ;
++        let dbg = Debug_info.to_string di in
++        Impl.VDI.revert context ~dbg ~sr ~snapshot_info
++
+       let stat context ~dbg ~sr ~vdi =
+         with_dbg ~name:"VDI.stat" ~dbg @@ fun di ->
+         info "VDI.stat dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr) (s_of_vdi vdi) ;

--- a/SOURCES/0038-CA-143836-Add-VDI.revert-API-call.patch
+++ b/SOURCES/0038-CA-143836-Add-VDI.revert-API-call.patch
@@ -1,0 +1,195 @@
+From 926b095f783fefa2fcfe63021e6d7dd241d7d419 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Thu, 2 Oct 2025 17:09:28 +0100
+Subject: [PATCH] CA-143836: Add VDI.revert API call
+
+The API function is needed to be able to forward it across the pool and
+to block other operations on the VDI while it's running.
+
+It's unused for the time being.
+
+Signed-off-by: John Else <john.else@citrix.com>
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/idl/datamodel.ml                     | 12 ++++++++++
+ ocaml/idl/datamodel_common.ml              |  2 +-
+ ocaml/tests/record_util/old_record_util.ml |  2 ++
+ ocaml/xapi-cli-server/record_util.ml       |  2 ++
+ ocaml/xapi/message_forwarding.ml           | 17 ++++++++++++++
+ ocaml/xapi/xapi_sr_operations.ml           |  2 ++
+ ocaml/xapi/xapi_vdi.ml                     | 27 ++++++++++++++++++++++
+ ocaml/xapi/xapi_vdi.mli                    |  2 ++
+ 8 files changed, 65 insertions(+), 1 deletion(-)
+
+diff --git a/ocaml/idl/datamodel.ml b/ocaml/idl/datamodel.ml
+index 16bd65622..83c3d97b6 100644
+--- a/ocaml/idl/datamodel.ml
++++ b/ocaml/idl/datamodel.ml
+@@ -4267,6 +4267,7 @@ module SR = struct
+         ; ("vdi_generate_config", "Generating the configuration of the VDI")
+         ; ("vdi_resize_online", "Resizing the VDI online")
+         ; ("vdi_update", "Refreshing the fields on the VDI")
++        ; ("vdi_revert", "Reverting a VDI to the snapshot")
+         ; ("pbd_create", "Creating a PBD for this SR")
+         ; ("pbd_destroy", "Destroying one of this SR's PBDs")
+         ]
+@@ -5447,6 +5448,16 @@ module VDI = struct
+          different SR. The destination SR must be visible to the guest."
+       ~allowed_roles:_R_VM_POWER_ADMIN ()
+ 
++  let revert =
++    call ~name:"revert" ~in_oss_since:None ~lifecycle:[]
++      ~params:
++        [(Ref _vdi, "snapshot", "The snapshot to which we want to revert")]
++      ~doc:
++        "Copy the contents of a snapshot to the VDI it's related to. The \
++         original contents of the VDI are lost."
++      ~errs:[Api_errors.unimplemented_in_sm_backend]
++      ~allowed_roles:_R_VM_POWER_ADMIN ~doc_tags:[Snapshots] ()
++
+   let introduce_params first_rel =
+     [
+       {
+@@ -6229,6 +6240,7 @@ module VDI = struct
+         ; data_destroy
+         ; list_changed_blocks
+         ; get_nbd_info
++        ; revert
+         ]
+       ~contents:
+         ([
+diff --git a/ocaml/idl/datamodel_common.ml b/ocaml/idl/datamodel_common.ml
+index bb8413396..93a3fbc6f 100644
+--- a/ocaml/idl/datamodel_common.ml
++++ b/ocaml/idl/datamodel_common.ml
+@@ -10,7 +10,7 @@ open Datamodel_roles
+               to leave a gap for potential hotfixes needing to increment the schema version.*)
+ let schema_major_vsn = 5
+ 
+-let schema_minor_vsn = 793
++let schema_minor_vsn = 794
+ 
+ (* Historical schema versions just in case this is useful later *)
+ let rio_schema_major_vsn = 5
+diff --git a/ocaml/tests/record_util/old_record_util.ml b/ocaml/tests/record_util/old_record_util.ml
+index ba01a52d3..d6850e7d2 100644
+--- a/ocaml/tests/record_util/old_record_util.ml
++++ b/ocaml/tests/record_util/old_record_util.ml
+@@ -360,6 +360,8 @@ let sr_operation_to_string : API.storage_operations -> string = function
+       "VDI.resize_online"
+   | `vdi_update ->
+       "VDI.update"
++  | `vdi_revert ->
++      "VDI.revert"
+ 
+ let vbd_operation_to_string = function
+   | `attach ->
+diff --git a/ocaml/xapi-cli-server/record_util.ml b/ocaml/xapi-cli-server/record_util.ml
+index a11b30dec..cf6042eee 100644
+--- a/ocaml/xapi-cli-server/record_util.ml
++++ b/ocaml/xapi-cli-server/record_util.ml
+@@ -175,6 +175,8 @@ let sr_operation_to_string : API.storage_operations -> string = function
+       "VDI.resize_online"
+   | `vdi_update ->
+       "VDI.update"
++  | `vdi_revert ->
++      "VDI.revert"
+   | `pbd_create ->
+       "PBD.create"
+   | `pbd_destroy ->
+diff --git a/ocaml/xapi/message_forwarding.ml b/ocaml/xapi/message_forwarding.ml
+index 83786bd8a..7e12dbf5f 100644
+--- a/ocaml/xapi/message_forwarding.ml
++++ b/ocaml/xapi/message_forwarding.ml
+@@ -5438,6 +5438,23 @@ functor
+             forward_vdi_op ~local_fn ~__context ~self:vdi ~remote_fn
+         )
+ 
++      let revert ~__context ~snapshot =
++        let ( let@ ) f x = f x in
++        let doc = "VDI.revert" in
++        info "%s: snapshot = '%s'" doc (vdi_uuid ~__context snapshot) ;
++        let local_fn = Local.VDI.revert ~snapshot in
++        let remote_fn = Client.VDI.revert ~snapshot in
++        let sr = Db.VDI.get_SR ~__context ~self:snapshot in
++        let vdi = Db.VDI.get_snapshot_of ~__context ~self:snapshot in
++        let op () =
++          forward_vdi_op ~local_fn ~__context ~self:snapshot ~remote_fn
++        in
++        let@ () =
++          with_sr_andor_vdi ~__context ~sr:(sr, `vdi_revert)
++            ~vdi:(snapshot, `revert_to) ~doc
++        in
++        with_sr_andor_vdi ~__context ~vdi:(vdi, `revert_from) ~doc op
++
+       let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
+         info "VDI.copy: VDI = '%s'; SR = '%s'; base_vdi = '%s'; into_vdi = '%s'"
+           (vdi_uuid ~__context vdi) (sr_uuid ~__context sr)
+diff --git a/ocaml/xapi/xapi_sr_operations.ml b/ocaml/xapi/xapi_sr_operations.ml
+index e74e19863..f011a7d7f 100644
+--- a/ocaml/xapi/xapi_sr_operations.ml
++++ b/ocaml/xapi/xapi_sr_operations.ml
+@@ -48,6 +48,7 @@ let all_ops : API.storage_operations_set =
+   ; `vdi_list_changed_blocks
+   ; `vdi_set_on_boot
+   ; `vdi_introduce
++  ; `vdi_revert
+   ; `update
+   ; `pbd_create
+   ; `pbd_destroy
+@@ -89,6 +90,7 @@ let sm_cap_table : (API.storage_operations * _) list =
+   ; (`vdi_list_changed_blocks, Vdi_configure_cbt)
+   ; (`vdi_set_on_boot, Vdi_reset_on_boot)
+   ; (`update, Sr_update)
++  ; (`vdi_revert, Vdi_revert)
+   ; (* We fake clone ourselves *)
+     (`vdi_snapshot, Vdi_snapshot)
+   ]
+diff --git a/ocaml/xapi/xapi_vdi.ml b/ocaml/xapi/xapi_vdi.ml
+index a847093bb..ab1e6063c 100644
+--- a/ocaml/xapi/xapi_vdi.ml
++++ b/ocaml/xapi/xapi_vdi.ml
+@@ -1118,6 +1118,33 @@ let clone ~__context ~vdi ~driver_params =
+       )
+   )
+ 
++let revert' ~__context ~snapshot =
++  let module C = Storage_interface.StorageAPI (Idl.Exn.GenClient (struct
++    let rpc = Storage_access.rpc
++  end)) in
++  let sr = Db.VDI.get_SR ~__context ~self:snapshot in
++  Sm.assert_pbd_is_plugged ~__context ~sr ;
++  Xapi_vdi_helpers.assert_managed ~__context ~vdi:snapshot ;
++  let snapshot_rec = Db.VDI.get_record ~__context ~self:snapshot in
++
++  let task = Context.get_task_id __context in
++  let snapshot_info =
++    Storage_smapiv1.vdi_info_of_vdi_rec __context snapshot_rec
++  in
++  let sr' =
++    Db.SR.get_uuid ~__context ~self:sr |> Storage_interface.Sr.of_string
++  in
++  (* We don't use transform_storage_exn because of the fallback below *)
++  C.VDI.revert (Ref.string_of task) sr' snapshot_info
++
++let revert ~__context ~snapshot =
++  Storage_utils.transform_storage_exn @@ fun () ->
++  try revert' ~__context ~snapshot
++  with Storage_interface.Storage_error (Unimplemented _) ->
++    debug "Backend does not implement VDI revert: doing it ourselves" ;
++    let msg = [Ref.string_of (Db.VDI.get_SR ~__context ~self:snapshot)] in
++    raise Api_errors.(Server_error (unimplemented_in_sm_backend, msg))
++
+ let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
+   Xapi_vdi_helpers.assert_managed ~__context ~vdi ;
+   let task_id = Ref.string_of (Context.get_task_id __context) in
+diff --git a/ocaml/xapi/xapi_vdi.mli b/ocaml/xapi/xapi_vdi.mli
+index 3d60ad31f..68d15e56d 100644
+--- a/ocaml/xapi/xapi_vdi.mli
++++ b/ocaml/xapi/xapi_vdi.mli
+@@ -258,3 +258,5 @@ val _get_nbd_info :
+     [get_server_certificate] function can be provided to avoid querying the real
+     certificate using the Client module, which is what {!get_nbd_info} does,
+     which would cause the unit test to fail. *)
++
++val revert : __context:Context.t -> snapshot:[`VDI] Ref.t -> unit

--- a/SOURCES/0039-xapi_vm_snapshot-change-VM.revert-to-use-VDI.revert.patch
+++ b/SOURCES/0039-xapi_vm_snapshot-change-VM.revert-to-use-VDI.revert.patch
@@ -1,0 +1,404 @@
+From 3c8519421ac253c3e87ee3745fe2315ffad0ff2b Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Mon, 6 Oct 2025 11:15:11 +0100
+Subject: [PATCH] xapi_vm_snapshot: change VM.revert to use VDI.revert
+
+The code now tries to call VDI.revert on all the disk VDIs, and if that
+fails, it falls back to the original revert method that destroys VM
+disks, clones snapshot disks and then fixes up metadata.
+
+This means that the successfully reverted disks must be excluded from
+the original method. This is done by introducing sets of VDIs and VBDs
+and using set logic on them.
+
+The CD disks and the suspend VDI are treated like before: destroy +
+clone.
+
+The code is more convoluted that I would have liked because of existing
+clone infrastructure mixes VBDs with VDIs, so they need to be converted
+back and forth to be able to run the previous method correctly,
+especially for updating the snapshot_of field of the cloned snapshot
+disks.
+
+Quicktests encodes the difference in behaviour from the original method
+to the native one: now VDI UUIDs are not changed when reverting.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/idl/schematest.ml                  |   2 +-
+ ocaml/quicktest/qt_filter.ml             |  12 +-
+ ocaml/quicktest/qt_filter.mli            |   2 +
+ ocaml/quicktest/quicktest_vm_snapshot.ml |  41 +++++-
+ ocaml/xapi/xapi_vm_snapshot.ml           | 177 ++++++++++++++++++-----
+ 5 files changed, 180 insertions(+), 54 deletions(-)
+
+diff --git a/ocaml/idl/schematest.ml b/ocaml/idl/schematest.ml
+index 0d75d41d0..f5a188444 100644
+--- a/ocaml/idl/schematest.ml
++++ b/ocaml/idl/schematest.ml
+@@ -3,7 +3,7 @@ let hash x = Digest.string x |> Digest.to_hex
+ (* BEWARE: if this changes, check that schema has been bumped accordingly in
+    ocaml/idl/datamodel_common.ml, usually schema_minor_vsn *)
+ 
+-let last_known_schema_hash = "f828a19597e924bede4f41b98c166795"
++let last_known_schema_hash = "199f30c56632b4780af33b04f57e16e9"
+ 
+ let current_schema_hash : string =
+   let open Datamodel_types in
+diff --git a/ocaml/quicktest/qt_filter.ml b/ocaml/quicktest/qt_filter.ml
+index 7ad7e2e83..c710d611f 100644
+--- a/ocaml/quicktest/qt_filter.ml
++++ b/ocaml/quicktest/qt_filter.ml
+@@ -1,3 +1,4 @@
++module Listext = Xapi_stdext_std.Listext.List
+ module A = Quicktest_args
+ 
+ type 'a test_case = string * Alcotest.speed_level * 'a
+@@ -280,14 +281,13 @@ module SR = struct
+     )
+ 
+   let allowed_operations ops =
+-    sr_filter (fun i ->
+-        Xapi_stdext_std.Listext.List.subset ops i.Qt.allowed_operations
+-    )
++    sr_filter (fun i -> Listext.subset ops i.Qt.allowed_operations)
+ 
+   let has_capabilities caps =
+-    sr_filter (fun i ->
+-        Xapi_stdext_std.Listext.List.subset caps i.Qt.capabilities
+-    )
++    sr_filter (fun i -> Listext.subset caps i.Qt.capabilities)
++
++  let unavailable_operations ops =
++    sr_filter (fun i -> not (Listext.subset ops i.Qt.allowed_operations))
+ 
+   (* Helper to filter SRs of specific types *)
+   let has_one_of_types types sr_info =
+diff --git a/ocaml/quicktest/qt_filter.mli b/ocaml/quicktest/qt_filter.mli
+index ba8a74163..1fea4e804 100644
+--- a/ocaml/quicktest/qt_filter.mli
++++ b/ocaml/quicktest/qt_filter.mli
+@@ -60,6 +60,8 @@ module SR : sig
+ 
+   val allowed_operations : API.storage_operations_set -> srs -> srs
+ 
++  val unavailable_operations : API.storage_operations_set -> srs -> srs
++
+   val has_capabilities : string list -> srs -> srs
+ 
+   val has_type : string -> srs -> srs
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index eb758fb35..6463922b7 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -143,7 +143,7 @@ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
+     (has_been_snapshot "1") ;
+   check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
+ 
+-let test_revert rpc session_id vm vdi vdi2 =
++let test_revert rpc session_id vm vdi vdi2 ~change =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+   Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
+ 
+@@ -151,9 +151,14 @@ let test_revert rpc session_id vm vdi vdi2 =
+   let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
+   let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
+ 
+-  (* Xapi forces VDI clones, the VDIs' IDs will always change *)
+-  check_vdis_different vdi vdi_after ;
+-  check_vdis_different vdi2 vdi_after2
++  let check =
++    if change then
++      (* Xapi forces VDI clones, the VDIs' IDs will always change *)
++      check_vdis_different
++    else
++      check_vdis_same
++  in
++  check vdi vdi_after ; check vdi2 vdi_after2
+ 
+ let test_revert_cds rpc session_id vm vdi vdi2 =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
+@@ -178,13 +183,35 @@ let suite name with_setup tests sr_ops =
+   |> sr SR.(all |> allowed_operations sr_ops)
+   |> vm_template Qt.VM.Template.other
+ 
++let suite_split_revert name with_setup =
++  let open Qt_filter in
++  let needed_ops = [`vdi_create] in
++  let old_ops = [`vdi_clone] in
++  let new_ops = [`vdi_revert] in
++  let sr_candidates = SR.(all |> allowed_operations needed_ops) in
++  let sr_native = sr_candidates |> SR.allowed_operations new_ops in
++  let sr_clonables =
++    sr_candidates
++    |> SR.unavailable_operations new_ops
++    |> SR.allowed_operations old_ops
++  in
++  let tests (filter_name, sr_filter) tests_f =
++    let name = Printf.sprintf "%s (%s)" name filter_name in
++    [(name, `Slow, a_test with_setup tests_f)]
++    |> conn
++    |> sr sr_filter
++    |> vm_template Qt.VM.Template.other
++  in
++  tests ("with VDI.revert", sr_native) [test_revert ~change:false]
++  @ tests ("with cloning method", sr_clonables) [test_revert ~change:true]
++
+ let tests () =
+   List.concat
+     [
+-      suite "VM snapshot tests" with_setup
++      suite "VM snapshot" with_setup
+         [test_snapshot; test_snapshot_ignore_vdi]
+         [`vdi_create]
+-    ; suite "VM revert tests" with_setup [test_revert] [`vdi_create; `vdi_clone]
+-    ; suite "VM revert with CD tests" with_cd_setup [test_revert_cds]
++    ; suite_split_revert "VM revert" with_setup
++    ; suite "VM revert with CD" with_cd_setup [test_revert_cds]
+         [`vdi_create; `vdi_clone]
+     ]
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index 3392c34c9..0f4324b27 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -211,61 +211,155 @@ let with_vdis_on_error ~vdis f = try f () with e -> Error (e, vdis)
+ 
+ let ( let@ ) f x = f x
+ 
+-(* Copy the VBDs and VIFs from a source VM to a dest VM and then delete the old
+-   disks. This operation destroys the data of the dest VM. *)
++(* Revert the VBDs of a VM to have the contents of the snapshot and copy the
++   VIFs from a snapshot VM to the VM. This operation destroys the data of the
++   dest VM. *)
++
+ type cloned = {
+     disks: ([`VBD] Ref.t * API.ref_VDI * bool) list
+   ; cds: ([`VBD] Ref.t * API.ref_VDI * bool) list
+   ; suspend_VDI: [`VDI] Ref.t
+ }
+ 
++module VDISet = Set.Make (struct
++  type t = [`VDI] Ref.t
++
++  let compare = Ref.compare
++end)
++
++module VBDSet = Set.Make (struct
++  type t = [`VBD] Ref.t
++
++  let compare = Ref.compare
++end)
++
+ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+-  let snap_VBDs = Db.VM.get_VBDs ~__context ~self:snapshot in
++  let get_snapshot_of vdi = Db.VDI.get_snapshot_of ~__context ~self:vdi in
++
++  let disks_of_vbds vbds =
++    vbds
++    |> VBDSet.to_seq
++    |> Seq.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd)
++    |> VDISet.of_seq
++  in
++
+   let snap_VBDs_disk, snap_VBDs_CD =
+-    List.partition
+-      (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
+-      snap_VBDs
+-  in
+-  let snap_disks =
+-    List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) snap_VBDs_disk
+-  in
+-  let snap_disks_snapshot_of =
+-    List.map (fun vdi -> Db.VDI.get_snapshot_of ~__context ~self:vdi) snap_disks
++    Db.VM.get_VBDs ~__context ~self:snapshot
++    |> VBDSet.of_list
++    |> VBDSet.partition (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
+   in
+   let snap_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:snapshot in
++  let snap_disks_all = disks_of_vbds snap_VBDs_disk in
++  let snap_disks_snapshot_of = VDISet.map get_snapshot_of snap_disks_all in
+ 
+-  let vm_VBDs = Db.VM.get_VBDs ~__context ~self:vm in
+-  (* Filter VBDs to ensure that we don't read empty CDROMs *)
++  let vm_VBDs_all = Db.VM.get_VBDs ~__context ~self:vm |> VBDSet.of_list in
+   let vm_VBDs_disk =
+-    List.filter
++    (* Filter VBDs to ensure that we don't read empty CDROMs *)
++    VBDSet.filter
+       (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
+-      vm_VBDs
++      vm_VBDs_all
+   in
+-  (* Filter out VM disks for which the snapshot does not have a corresponding
+-     disk - these disks will be left unattached after the revert is complete. *)
+-  let vm_disks =
+-    List.map (fun vbd -> Db.VBD.get_VDI ~__context ~self:vbd) vm_VBDs_disk
+-  in
+-  let vm_disks_with_snapshot =
+-    List.filter (fun vdi -> List.mem vdi snap_disks_snapshot_of) vm_disks
+-  in
+-  let vm_suspend_VDI = Db.VM.get_suspend_VDI ~__context ~self:vm in
++  let vm_disks_all = disks_of_vbds vm_VBDs_disk in
+ 
+-  debug "Cleaning up the old VBDs and VDIs to have more free space" ;
+-  List.iter (safe_destroy_vbd ~__context ~rpc ~session_id) vm_VBDs ;
+-  List.iter
++  let vm_suspend_VDI =
++    Db.VM.get_suspend_VDI ~__context ~self:vm |> VDISet.singleton
++  in
++
++  if VDISet.cardinal snap_disks_all <> 0 then
++    debug "%s: trying to revert VDIs using VDI.revert" __FUNCTION__ ;
++
++  let snap_disks_reverted =
++    VDISet.filter
++      (fun snapshot ->
++        try
++          Client.VDI.revert ~rpc ~session_id ~snapshot ;
++          true
++        with _ -> false
++      )
++      snap_disks_all
++  in
++
++  let vm_disks_already_reverted =
++    VDISet.map get_snapshot_of snap_disks_reverted
++  in
++
++  let vm_disks_to_be_destroyed =
++    let ( --- ) = VDISet.diff in
++    let ( +++ ) = VDISet.union in
++
++    (* Disks without snapshot are left unattached after the revert is complete. *)
++    let vm_disks_without_snapshot = vm_disks_all --- snap_disks_snapshot_of in
++
++    vm_disks_all
++    --- vm_disks_without_snapshot
++    --- vm_disks_already_reverted
++    +++ vm_suspend_VDI
++  in
++
++  let filter_vbds_from_vdis vbds vdis =
++    vbds
++    |> VBDSet.filter (fun vbd ->
++        VDISet.mem (Db.VBD.get_VDI ~__context ~self:vbd) vdis
++    )
++  in
++
++  let vm_vbds_to_be_destroyed =
++    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed
++  in
++
++  let snap_VBDs_reverted =
++    filter_vbds_from_vdis snap_VBDs_disk snap_disks_reverted
++  in
++
++  (*
++     snap VBDs (disk)
++   - snap VBDs from reverted disks
++   = snap VBDs to be cloned
++   *)
++  let snap_VBDs_to_be_cloned =
++    let ( --- ) = VBDSet.diff in
++    snap_VBDs_disk --- snap_VBDs_reverted
++  in
++  if
++    VBDSet.cardinal vm_vbds_to_be_destroyed <> 0
++    || VDISet.cardinal vm_disks_to_be_destroyed <> 0
++  then
++    debug "%s: Cleaning up the old VBDs and VDIs to have more free space"
++      __FUNCTION__ ;
++  VBDSet.iter
++    (safe_destroy_vbd ~__context ~rpc ~session_id)
++    vm_vbds_to_be_destroyed ;
++  VDISet.iter
+     (safe_destroy_vdi ~__context ~rpc ~session_id)
+-    (vm_suspend_VDI :: vm_disks_with_snapshot) ;
++    vm_disks_to_be_destroyed ;
+   TaskHelper.set_progress ~__context 0.2 ;
+-  debug "Cloning the snapshotted disks" ;
++  if VBDSet.cardinal snap_VBDs_to_be_cloned <> 0 then
++    debug "%s: Cloning the snapshotted disks" __FUNCTION__ ;
++
+   let driver_params = Xapi_vm_clone.make_driver_params () in
+   let cloned_disks =
+-    Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
+-      ~__context snap_VBDs_disk driver_params
++    (* the list of cloned VDIs maintains the order of the VBDs given, use this
++       to correlate the VDI with the original VDI before the clone *)
++    let snap_VBDs_to_be_cloned =
++      snap_VBDs_to_be_cloned |> VBDSet.to_seq |> List.of_seq
++    in
++    let snap_disks_previous_snapshot_of =
++      snap_VBDs_to_be_cloned
++      |> List.map (fun vbd ->
++          let vdi = Db.VBD.get_VDI ~__context ~self:vbd in
++          Db.VDI.get_snapshot_of ~__context ~self:vdi
++      )
++    in
++
++    let cloned =
++      Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
++        ~__context snap_VBDs_to_be_cloned driver_params
++    in
++    List.combine cloned snap_disks_previous_snapshot_of
+   in
+   let destroy_vdis_on_error =
+     List.filter_map
+-      (fun (_, vdi, on_error_delete) ->
++      (fun ((_, vdi, on_error_delete), _) ->
+         if on_error_delete then
+           Some vdi
+         else
+@@ -275,20 +369,22 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+   in
+   let@ () = with_vdis_on_error ~vdis:destroy_vdis_on_error in
+   let cloned_CDs =
++    let snap_VBDs_CD = snap_VBDs_CD |> VBDSet.to_seq |> List.of_seq in
+     Xapi_vm_clone.safe_clone_disks rpc session_id Xapi_vm_clone.Disk_op_clone
+       ~__context snap_VBDs_CD driver_params
+   in
+   TaskHelper.set_progress ~__context 0.5 ;
+-  debug "Updating the snapshot_of fields for relevant VDIs" ;
+-  List.iter2
+-    (fun snap_disk (_, cloned_disk, _) ->
++  if cloned_disks <> [] then
++    debug "%s: Updating the snapshot_of fields for relevant VDIs" __FUNCTION__ ;
++
++  List.iter
++    (fun ((_, cloned_disk, _), snapshot_of) ->
+       (* For each snapshot disk which was just cloned:
+          1) Find the value of snapshot_of
+          2) Find all snapshots with the same snapshot_of
+          3) Update each of these snapshots so that their snapshot_of points
+             to the new cloned disk. *)
+       let open Xapi_database.Db_filter_types in
+-      let snapshot_of = Db.VDI.get_snapshot_of ~__context ~self:snap_disk in
+       let all_snaps_in_tree =
+         Db.VDI.get_refs_where ~__context
+           ~expr:(Eq (Field "snapshot_of", Literal (Ref.string_of snapshot_of)))
+@@ -299,7 +395,7 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+         )
+         all_snaps_in_tree
+     )
+-    snap_disks cloned_disks ;
++    cloned_disks ;
+   debug "Cloning the suspend VDI if needed" ;
+   let cloned_suspend_VDI =
+     if snap_suspend_VDI = Ref.null then
+@@ -310,12 +406,13 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+   in
+   let destroy_vdis_on_error = cloned_suspend_VDI :: destroy_vdis_on_error in
+   let@ () = with_vdis_on_error ~vdis:destroy_vdis_on_error in
++  let vbds_to_copy = List.map fst cloned_disks @ cloned_CDs in
+   TaskHelper.set_progress ~__context 0.6 ;
+-  debug "Copying the VBDs" ;
++  if vbds_to_copy <> [] then debug "%s: Copying the VBDs" __FUNCTION__ ;
+   let (_ : [`VBD] Ref.t list) =
+     List.map
+       (fun (vbd, vdi, _) -> Xapi_vbd_helpers.copy ~__context ~vm ~vdi vbd)
+-      (cloned_disks @ cloned_CDs)
++      vbds_to_copy
+   in
+   debug "Update the suspend_VDI" ;
+   Db.VM.set_suspend_VDI ~__context ~self:vm ~value:cloned_suspend_VDI ;

--- a/SOURCES/0040-datamodel_lifecycle-bump.patch
+++ b/SOURCES/0040-datamodel_lifecycle-bump.patch
@@ -1,0 +1,22 @@
+From e021d89fb5905315a1bd5ff75f39954cdf52b273 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 5 Jun 2026 16:56:39 +0100
+Subject: [PATCH] datamodel_lifecycle: bump
+
+---
+ ocaml/idl/datamodel_lifecycle.ml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/ocaml/idl/datamodel_lifecycle.ml b/ocaml/idl/datamodel_lifecycle.ml
+index f60c057a1..fa681cce9 100644
+--- a/ocaml/idl/datamodel_lifecycle.ml
++++ b/ocaml/idl/datamodel_lifecycle.ml
+@@ -237,6 +237,8 @@ let prototyped_of_message = function
+       Some "22.26.0"
+   | "VTPM", "create" ->
+       Some "22.26.0"
++  | "VDI", "revert" ->
++      Some "26.1.4-next"
+   | "host", "set_servertime" ->
+       Some "26.0.0"
+   | "host", "get_ntp_synchronized" ->

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.4
-Release: 3%{?xsrel}.2%{?dist}
+Release: 3%{?xsrel}.3%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -129,6 +129,28 @@ Patch1019: 0019-Refresh-remote-session-during-long-migrations.patch
 # in v26.1.7 upstream
 Patch1020: 0020-Don-t-deny-smartcards-in-usb-policy.conf.patch
 
+# Upstream PR: https://github.com/xapi-project/xen-api/pull/7116
+# (not merged at the time of writing)
+Patch1021: 0021-gitignore-ignore-_mock-directory.patch
+Patch1022: 0022-record_util-move-to-a-new-private-library.patch
+Patch1023: 0023-ocaml-tests-separate-test_sr_allowed_operations.patch
+Patch1024: 0024-xapi_sr_operations-use-results-for-asserting-valid-o.patch
+Patch1025: 0025-xapi_sr_operations-ensure-the-properties-on-ops-list.patch
+Patch1026: 0026-xapi-storage-add-interface-to-common.patch
+Patch1027: 0027-xapi_vdi-removed-code-commented-in-the-prehistoric-t.patch
+Patch1028: 0028-quicktest-reduce-amount-of-repetition-in-snapshot-te.patch
+Patch1029: 0029-quicktest-switch-asserts-with-alcotest-s-check-in-sn.patch
+Patch1030: 0030-quicktest-test-reverting-snapshots.patch
+Patch1031: 0031-quicktest-test-snapshot-revert-with-CDs.patch
+Patch1032: 0032-xapi_vm_snapshot-Plug-out-destroying-and-cloning-dis.patch
+Patch1033: 0033-xapi_vm_snapshot-move-VDI-related-DB-operations-insi.patch
+Patch1034: 0034-xapi_vm_snapshot-cover-more-code-to-destroy-newly-cl.patch
+Patch1035: 0035-xapi_vm_snapshot-shorten-length-of-comments.patch
+Patch1036: 0036-xapi_vdi-Introduce-VDI-operations-needed-for-revert.patch
+Patch1037: 0037-storage-add-VDI.revert.patch
+Patch1038: 0038-CA-143836-Add-VDI.revert-API-call.patch
+Patch1039: 0039-xapi_vm_snapshot-change-VM.revert-to-use-VDI.revert.patch
+Patch1040: 0040-datamodel_lifecycle-bump.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1530,8 +1552,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
-# * next
-# - Add dmidecode to xapi-core Requires
+* Fri Jun 05 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.4-3.3
+- Foundational changes for having a more efficient and safer VM revert
+- Add dmidecode to xapi-core Requires
 
 * Fri May 22 2026 Tu Dinh <ngoc-tu.dinh@vates.tech> - 26.1.4-3.2
 - Don't deny smartcards in usb-policy.conf


### PR DESCRIPTION
#### Context & Motivation

This change removes enables the removal of the writing of `snapshot_of` both for VDIs and VM objects while a VM is reverted, one of the issues that is now very common among customers.

To fully realise this potential, a new version of `sm` with the storage backends implementing the operation VDI_REVERT is needed.

More technical information can be found in
https://xapi-project.github.io/new-docs/design/snapshot-revert/

#### Release Target

- [x] We already defined a release target with the release team.

8.3-next+1

---

### Release Notes and Documentation

#### Explain the change to users

None of note, this is foundational update and should not have visible change in behaviour.

#### Attention points

N/A

#### Documentation update needed

- [x] No

---

### Testing and regression avoidance

#### What tests have you performed?

Unit-tests have been added testing some parts of the code, revert tests have been added to quicktests. 

I've run the quicktests manually on my host both with a current `sm`, and an experimental one which exposes VDI_REVERT.

#### What manual tests should be performed after the build, and by whom?

The release team may want to test snapshots and reverts.

#### What's covered by the xcp-ng-tests test suite?

The quicktests are run, so tests with the SR backedns available to the hosts at the time of testing are tested.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [x] No