### PR TITLE
Add new patch for VM revert

### DIFF
--- a/SOURCES/0027-xapi_vm_snapshot-Fail-VM.revert-when-a-VDI.revert-ac.patch
+++ b/SOURCES/0027-xapi_vm_snapshot-Fail-VM.revert-when-a-VDI.revert-ac.patch
@@ -1,0 +1,82 @@
+From 79878daca72e7a479fa182c8d84af10f4f7950f7 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Fri, 12 Jun 2026 10:04:35 +0100
+Subject: [PATCH] xapi_vm_snapshot: Fail VM.revert when a VDI.revert actually
+ fails
+
+In case where there's an error while reverting on the Storage Backend,
+the state of the SR might become unstable, and a recovery using the
+clone method for reverting might introduce bigger issues. Instead stop
+the revert immediately.
+
+The cases where ignoring the errors is acceptable is when either the SR
+does not advertise support for VDI_REVERT, and when the SR does not
+implement revert for a particular VDI. for example, if the SR implements
+the revert for only some of the formats it implements.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+---
+ ocaml/xapi/storage_smapiv1.ml  | 11 +++++++----
+ ocaml/xapi/xapi_vdi.ml         |  3 +++
+ ocaml/xapi/xapi_vm_snapshot.ml |  7 ++++++-
+ 3 files changed, 16 insertions(+), 5 deletions(-)
+
+diff --git a/ocaml/xapi/storage_smapiv1.ml b/ocaml/xapi/storage_smapiv1.ml
+index 3d39cf320..dcafdedea 100644
+--- a/ocaml/xapi/storage_smapiv1.ml
++++ b/ocaml/xapi/storage_smapiv1.ml
+@@ -1135,10 +1135,13 @@ module SMAPIv1 : Server_impl = struct
+     let revert _context ~dbg ~sr ~snapshot_info =
+       with_dbg ~name:"VDI.revert" ~dbg @@ fun di ->
+       let dbg = Debug_info.to_string di in
+-      Server_helpers.exec_with_new_task "VDI.revert"
+-        ~subtask_of:(Ref.of_string dbg) (fun __context ->
+-          call_revert ~__context ~dbg ~sr ~snapshot_info
+-      )
++      try
++        Server_helpers.exec_with_new_task "VDI.revert"
++          ~subtask_of:(Ref.of_string dbg) (fun __context ->
++            call_revert ~__context ~dbg ~sr ~snapshot_info
++        )
++      with Smint.Not_implemented_in_backend ->
++        raise (Storage_error (Unimplemented "VDI.revert"))
+   end
+ 
+   let get_by_name _context ~dbg:_ ~name:_ = assert false
+diff --git a/ocaml/xapi/xapi_vdi.ml b/ocaml/xapi/xapi_vdi.ml
+index ab1e6063c..49235c717 100644
+--- a/ocaml/xapi/xapi_vdi.ml
++++ b/ocaml/xapi/xapi_vdi.ml
+@@ -1138,11 +1138,14 @@ let revert' ~__context ~snapshot =
+   C.VDI.revert (Ref.string_of task) sr' snapshot_info
+ 
+ let revert ~__context ~snapshot =
++  let __FUN = __FUNCTION__ in
+   Storage_utils.transform_storage_exn @@ fun () ->
+   try revert' ~__context ~snapshot
+   with Storage_interface.Storage_error (Unimplemented _) ->
+     debug "Backend does not implement VDI revert: doing it ourselves" ;
+     let msg = [Ref.string_of (Db.VDI.get_SR ~__context ~self:snapshot)] in
++    debug "%s: Backend reported not implemented despite it offering the feature"
++      __FUN ;
+     raise Api_errors.(Server_error (unimplemented_in_sm_backend, msg))
+ 
+ let copy ~__context ~vdi ~sr ~base_vdi ~into_vdi =
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index 0f4324b27..95764a6c4 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -274,7 +274,12 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+         try
+           Client.VDI.revert ~rpc ~session_id ~snapshot ;
+           true
+-        with _ -> false
++        with
++        | Api_errors.(Server_error (e, _))
++        when e = Api_errors.sr_operation_not_supported
++             || e = Api_errors.unimplemented_in_sm_backend
++        ->
++          false
+       )
+       snap_disks_all
+   in

--- a/SOURCES/0028-quicktest-test-for-number-of-CD-VBDs.patch
+++ b/SOURCES/0028-quicktest-test-for-number-of-CD-VBDs.patch
@@ -1,0 +1,35 @@
+From c7ca6e38fad70bd335c552c9cee86ce8fa1a0502 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 17 Jun 2026 16:11:31 +0100
+Subject: [PATCH] quicktest: test for number of CD VBDs
+
+This shows the current code leaks the VBDs
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+(cherry picked from commit 38cfbc549040b68f85d50e963546864ac2606a40)
+---
+ ocaml/quicktest/quicktest_vm_snapshot.ml | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index 6463922b7..0279f95d5 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -162,12 +162,17 @@ let test_revert rpc session_id vm vdi vdi2 ~change =
+ 
+ let test_revert_cds rpc session_id vm vdi vdi2 =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
++
++  let snap_vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:snapshot in
++  Alcotest.(check int) "Snapshot must only have 2 VBDs" 2 (List.length snap_vbds) ;
++
+   Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
+ 
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
+   let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
+   let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
+ 
++  Alcotest.(check int) "VM must only have 2 VBDs" 2 (List.length vbds) ;
+   (* CD VDIs are considered immutable and the clone code ignores them *)
+   check_vdis_same vdi vdi_after ;
+   check_vdis_same vdi2 vdi_after2

--- a/SOURCES/0029-xapi_vm_snapshot-do-not-leak-CD-VBDs.patch
+++ b/SOURCES/0029-xapi_vm_snapshot-do-not-leak-CD-VBDs.patch
@@ -1,0 +1,41 @@
+From 4d2ab4e6f133f395e7250186050eb326813c9595 Mon Sep 17 00:00:00 2001
+From: Pau Ruiz Safont <pau.safont@vates.tech>
+Date: Wed, 17 Jun 2026 16:14:42 +0100
+Subject: [PATCH] xapi_vm_snapshot: do not leak CD VBDs
+
+Because all the snapshot's CD VBDs are cloned in all cases, the reverted
+VM's CD VBDs must be destroyed in all cases, add them unconditionally to
+the VBDs being destroyed.
+
+Signed-off-by: Pau Ruiz Safont <pau.safont@vates.tech>
+(cherry picked from commit 20e8b3bb5b44406560d08fa6d5c925b089bfa091)
+---
+ ocaml/xapi/xapi_vm_snapshot.ml | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index 95764a6c4..4ecab7e58 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -253,9 +253,9 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+   let snap_disks_snapshot_of = VDISet.map get_snapshot_of snap_disks_all in
+ 
+   let vm_VBDs_all = Db.VM.get_VBDs ~__context ~self:vm |> VBDSet.of_list in
+-  let vm_VBDs_disk =
++  let vm_VBDs_disk, vm_VBDs_CD =
+     (* Filter VBDs to ensure that we don't read empty CDROMs *)
+-    VBDSet.filter
++    VBDSet.partition
+       (fun vbd -> Db.VBD.get_type ~__context ~self:vbd = `Disk)
+       vm_VBDs_all
+   in
+@@ -309,7 +309,8 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+   in
+ 
+   let vm_vbds_to_be_destroyed =
+-    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed
++    let ( +++ ) = VBDSet.union in
++    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed +++ vm_VBDs_CD
+   in
+ 
+   let snap_VBDs_reverted =

--- a/SOURCES/0030-datamodel_lifecycle-bump.patch
+++ b/SOURCES/0030-datamodel_lifecycle-bump.patch
@@ -1,4 +1,4 @@
-From ece03cbad180284c4b7a4a96db2aafd10174073d Mon Sep 17 00:00:00 2001
+From 097d1eb07f2d49a21429fb7418d5484242a2d0de Mon Sep 17 00:00:00 2001
 From: Pau Ruiz Safont <pau.safont@vates.tech>
 Date: Fri, 5 Jun 2026 16:56:39 +0100
 Subject: [PATCH] datamodel_lifecycle: bump

--- a/SOURCES/0031-xapi_vm_lifecycle-Only-consult-data-cant-suspend-rea.patch
+++ b/SOURCES/0031-xapi_vm_lifecycle-Only-consult-data-cant-suspend-rea.patch
@@ -1,4 +1,4 @@
-From 6f9a1a1a4ed2f6dc191dee4bfa0dc6d42450c20f Mon Sep 17 00:00:00 2001
+From c4938ec3294e176ea908986df998c03474a117c5 Mon Sep 17 00:00:00 2001
 From: Andrii Sultanov <andriy.sultanov@vates.tech>
 Date: Wed, 29 Apr 2026 08:30:59 +0000
 Subject: [PATCH] xapi_vm_lifecycle: Only consult data-cant-suspend-reason and

--- a/SOURCES/0032-Add-DHCP-setting-for-VIF-IP-configuration.patch
+++ b/SOURCES/0032-Add-DHCP-setting-for-VIF-IP-configuration.patch
@@ -1,4 +1,4 @@
-From 2e1706ced52c3756c732b08fd8bd064e122fd569 Mon Sep 17 00:00:00 2001
+From 264ebb41a63edb16caecab3a94dda18cc8f9982d Mon Sep 17 00:00:00 2001
 From: Tu Dinh <ngoc-tu.dinh@vates.tech>
 Date: Mon, 8 Jun 2026 18:01:14 +0200
 Subject: [PATCH] Add DHCP setting for VIF IP configuration

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.11
-Release: 1%{?xsrel}.1%{?dist}
+Release: 1%{?xsrel}.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -124,13 +124,16 @@ Patch1023: 0023-xapi_vdi-Introduce-VDI-operations-needed-for-revert.patch
 Patch1024: 0024-storage-add-VDI.revert.patch
 Patch1025: 0025-CA-143836-Add-VDI.revert-API-call.patch
 Patch1026: 0026-xapi_vm_snapshot-change-VM.revert-to-use-VDI.revert.patch
-Patch1027: 0027-datamodel_lifecycle-bump.patch
+Patch1027: 0027-xapi_vm_snapshot-Fail-VM.revert-when-a-VDI.revert-ac.patch
+Patch1028: 0028-quicktest-test-for-number-of-CD-VBDs.patch
+Patch1029: 0029-xapi_vm_snapshot-do-not-leak-CD-VBDs.patch
+Patch1030: 0030-datamodel_lifecycle-bump.patch
 
 # In v26.1.12 upstream
-Patch1028: 0028-xapi_vm_lifecycle-Only-consult-data-cant-suspend-rea.patch
+Patch1031: 0031-xapi_vm_lifecycle-Only-consult-data-cant-suspend-rea.patch
 
 # In v26.1.14 upstream
-Patch1029: 0029-Add-DHCP-setting-for-VIF-IP-configuration.patch
+Patch1032: 0032-Add-DHCP-setting-for-VIF-IP-configuration.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1532,6 +1535,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Mon Jun 15 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.11-1.2
+- Allow VM revert to fail when there's an actual error on VDI revert
+
 * Tue Jun 09 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.11-1.1
 - Fix shutdown VMs not being migratable due to errors generated when the VM was running
 - Allow moving VMs back to DHCP from static IP with configure_ipv4/6


### PR DESCRIPTION
XCPNG-3428


#### Related changes

This is a fix for XCPNG-2410 (https://github.com/xcp-ng-rpms/xapi/pull/133)

#### Context & Motivation

The work for better VM revert has a fallback mechanism when there's an error reverting a VDI, which allows it to proceed using the legacy method.

The storage team has notified that if there's a genuine error, they prefer that the revert is halted completely instead of trying the fallback because the snapshot tree in the SR might not be in a clean state.

This patch adds that: there's a fallback when the SR does not advertise VDI_REVERT, or it does not implement for the certain VDI type (for example, raw format); and it stops the process and fails when there's a genuine error.

#### Release Target

- [x] I have talked with the release team

8.3-next + 1

---

### Release Notes and Documentation

#### Explain the change to users

N/A

#### Attention points

N/A

#### Documentation update needed

- [x] No

### Testing and regression avoidance

#### What tests have you performed?

I've run quicktest with an old and new version of sm supporting VDI revert:

with `sm.x86_64 0:3.2.12-17.9.xcpng8.3`:
```
# /opt/xensource/debug/quicktest -run-only Quicktest_vm_snapshot
QCHECK_LONG_FACTOR: 10
qcheck random seed: 971327805
Choosing template with name: Other install media
Choosing template with name: Other install media
Choosing template with name: Other install media
Choosing template with name: Other install media
Testing `Quicktests'.
This run has ID `LEDISGAF'.

  [OK]          Quicktest_vm_snapshot          0   VM snapshot on SR [Local storage].
  [OK]          Quicktest_vm_snapshot          1   VM revert (with cloning method) on SR [Local storage].
  [OK]          Quicktest_vm_snapshot          2   VM revert with CD on SR [Local storage].

Full test results in `~/_build/_tests/Quicktests'.
Test Successful in 12.218s. 3 tests run.
```

with `sm.x86_64 0:3.2.12-21.9.0.vdirevert.4.xcpng8.3`:
```
# /opt/xensource/debug/quicktest -run-only Quicktest_vm_snapshot
QCHECK_LONG_FACTOR: 10
qcheck random seed: 187101054
Choosing template with name: Other install media
Choosing template with name: Other install media
Choosing template with name: Other install media
Choosing template with name: Other install media
Testing `Quicktests'.
This run has ID `EFWI93LZ'.

  [OK]          Quicktest_vm_snapshot          0   VM snapshot on SR [Local storage].
  [OK]          Quicktest_vm_snapshot          1   VM revert (with VDI.revert) on SR [Local storage].
  [OK]          Quicktest_vm_snapshot          2   VM revert with CD on SR [Local storage].

Full test results in `~/_build/_tests/Quicktests'.
Test Successful in 9.229s. 3 tests run.
```

#### What manual tests should be performed after the build, and by whom?

See https://github.com/xcp-ng-rpms/xapi/pull/133

#### What's covered by the xcp-ng-tests test suite?

See https://github.com/xcp-ng-rpms/xapi/pull/133

#### What tests have been or will be added to CI for this change? If none, explain why.

See https://github.com/xcp-ng-rpms/xapi/pull/133

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [x] No
