### PR TITLE
XCPNG-3498 - Backport a fix for VBDs staying attached after VM.revert

### DIFF
--- a/SOURCES/0033-CA-429144-Do-not-leak-new-vbds-after-snapshot.patch
+++ b/SOURCES/0033-CA-429144-Do-not-leak-new-vbds-after-snapshot.patch
@@ -1,0 +1,50 @@
+From 09b6c21839bf2471e77d50eab60c7ca07ead5127 Mon Sep 17 00:00:00 2001
+From: Changlei Li <changlei.li@citrix.com>
+Date: Wed, 1 Jul 2026 10:03:53 +0800
+Subject: [PATCH] CA-429144: Do not leak new vbds after snapshot
+
+Disks without snapshot are left unattached after the revert
+is complete. This is right but the vbds should be removed.
+
+Signed-off-by: Changlei Li <changlei.li@citrix.com>
+(cherry picked from commit 3a1d7145180df5250af005c06a9a8652b4ae7902)
+---
+ ocaml/xapi/xapi_vm_snapshot.ml | 13 +++++++++----
+ 1 file changed, 9 insertions(+), 4 deletions(-)
+
+diff --git a/ocaml/xapi/xapi_vm_snapshot.ml b/ocaml/xapi/xapi_vm_snapshot.ml
+index 4ecab7e58..24580c31e 100644
+--- a/ocaml/xapi/xapi_vm_snapshot.ml
++++ b/ocaml/xapi/xapi_vm_snapshot.ml
+@@ -288,14 +288,17 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+     VDISet.map get_snapshot_of snap_disks_reverted
+   in
+ 
++  let vm_disks_without_snapshot =
++    let ( --- ) = VDISet.diff in
++    vm_disks_all --- snap_disks_snapshot_of
++  in
++
+   let vm_disks_to_be_destroyed =
+     let ( --- ) = VDISet.diff in
+     let ( +++ ) = VDISet.union in
+ 
+-    (* Disks without snapshot are left unattached after the revert is complete. *)
+-    let vm_disks_without_snapshot = vm_disks_all --- snap_disks_snapshot_of in
+-
+     vm_disks_all
++    (* Disks without snapshot are left unattached after the revert is complete. *)
+     --- vm_disks_without_snapshot
+     --- vm_disks_already_reverted
+     +++ vm_suspend_VDI
+@@ -310,7 +313,9 @@ let revert_vbds ~__context ~rpc ~session_id ~snapshot ~vm =
+ 
+   let vm_vbds_to_be_destroyed =
+     let ( +++ ) = VBDSet.union in
+-    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed +++ vm_VBDs_CD
++    filter_vbds_from_vdis vm_VBDs_all vm_disks_to_be_destroyed
++    +++ filter_vbds_from_vdis vm_VBDs_all vm_disks_without_snapshot
++    +++ vm_VBDs_CD
+   in
+ 
+   let snap_VBDs_reverted =

--- a/SOURCES/0034-quicktest-Verify-non-snapshotted-VBDs-are-not-leaked.patch
+++ b/SOURCES/0034-quicktest-Verify-non-snapshotted-VBDs-are-not-leaked.patch
@@ -1,0 +1,46 @@
+From 8c5b575b5c2d74fc413397e482849fe0fd5cc879 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Fri, 3 Jul 2026 07:53:20 +0000
+Subject: [PATCH] quicktest: Verify non-snapshotted VBDs are not leaked on
+ VM.revert
+
+This is a follow-up to https://github.com/xapi-project/xen-api/pull/7156
+
+This quicktest fails without the fix above, and passes with it.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/quicktest/quicktest_vm_snapshot.ml | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/ocaml/quicktest/quicktest_vm_snapshot.ml b/ocaml/quicktest/quicktest_vm_snapshot.ml
+index 0279f95d5..dc594ecaf 100644
+--- a/ocaml/quicktest/quicktest_vm_snapshot.ml
++++ b/ocaml/quicktest/quicktest_vm_snapshot.ml
+@@ -144,12 +144,15 @@ let test_snapshot_ignore_vdi rpc session_id vm vdi vdi2 =
+   check_vdi_snapshot_of rpc session_id vbds ~vdi "0"
+ 
+ let test_revert rpc session_id vm vdi vdi2 ~change =
+-  let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in
++  let snapshot =
++    take_snapshot rpc session_id vm ~origin:__FUNCTION__ ~ignore_vdis:[vdi2]
++  in
+   Client.Client.VM.revert ~rpc ~session_id ~snapshot ;
+ 
+   let vbds = Client.Client.VM.get_VBDs ~rpc ~session_id ~self:vm in
++  Alcotest.(check int)
++    "There should only be one VBD after VM.revert" 1 (List.length vbds) ;
+   let vdi_after = get_vdi_with_user_device rpc session_id vbds "0" in
+-  let vdi_after2 = get_vdi_with_user_device rpc session_id vbds "1" in
+ 
+   let check =
+     if change then
+@@ -158,7 +161,7 @@ let test_revert rpc session_id vm vdi vdi2 ~change =
+     else
+       check_vdis_same
+   in
+-  check vdi vdi_after ; check vdi2 vdi_after2
++  check vdi vdi_after
+ 
+ let test_revert_cds rpc session_id vm vdi vdi2 =
+   let snapshot = take_snapshot rpc session_id vm ~origin:__FUNCTION__ in

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -103,8 +103,7 @@ Patch1006: 0006-xcp-ng-do-not-change-rsyslog-configuration.patch
 # still uses the legacy default for safety
 Patch1007: 0007-xapi.conf-Switch-to-optimized-data-cluster-format-fo.patch
 
-# Upstream PR: https://github.com/xapi-project/xen-api/pull/7116
-# (not merged at the time of writing)
+# In v26.1.14 upstream
 Patch1008: 0008-gitignore-ignore-_mock-directory.patch
 Patch1009: 0009-record_util-move-to-a-new-private-library.patch
 Patch1010: 0010-ocaml-tests-separate-test_sr_allowed_operations.patch
@@ -137,6 +136,9 @@ Patch1032: 0032-Add-DHCP-setting-for-VIF-IP-configuration.patch
 
 # In v26.1.15 upstream
 Patch1033: 0033-CA-429144-Do-not-leak-new-vbds-after-snapshot.patch
+
+# In v26.1.16 upstream
+Patch1034: 0034-quicktest-Verify-non-snapshotted-VBDs-are-not-leaked.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.11
-Release: 1%{?xsrel}.2%{?dist}
+Release: 1%{?xsrel}.3%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -134,6 +134,9 @@ Patch1031: 0031-xapi_vm_lifecycle-Only-consult-data-cant-suspend-rea.patch
 
 # In v26.1.14 upstream
 Patch1032: 0032-Add-DHCP-setting-for-VIF-IP-configuration.patch
+
+# In v26.1.15 upstream
+Patch1033: 0033-CA-429144-Do-not-leak-new-vbds-after-snapshot.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1535,6 +1538,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Fri Jul 03 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.11-1.3
+- Fix non-snapshotted VBDs staying attached after VM.revert
+
 * Mon Jun 15 2026 Pau Ruiz Safont <pau.safont@vates.tech> - 26.1.11-1.2
 - Allow VM revert to fail when there's an actual error on VDI revert
 


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3498

#### Context & Motivation

XenServer testing spotted a regression in the new `VM.revert` implementation - VBDs from disks without snapshots are left attached to the VM after `VM.revert`. This regression is in the common parts of the xapi code, which runs even if the storage backends do not implement `VM.revert`, so it's affecting all use-cases.

#### Release Target

- [X] We already defined a release target with the release team.

`8.3-next`

---

### Release Notes and Documentation

#### Explain the change to users

- Fix non-snapshotted VBDs staying attached after VM.revert

#### Attention points

I believe the actual issue is not quite as described in the upstream commit, and it's not possible to automatically resolve the VBDs that were already leaked for users on buggy versions.

##### Desired behaviour (was the case before xapi `26.1.4-3.3` and will be after this fix in `26.1.11-1.3`)

VBDs that were not snapshotted (either because they were explicitly ignored during snapshot or because they were added to the VM after the snapshot) are unattached and destroyed during `VM.revert`

Step-by-step:
1. VM only has `xvda` VBD
2. It's snapshotted
3. Another VBD is added as `xvdb`
4. VM is reverted
5. VM only has `xvda` VBD

##### Buggy behavior (bug present after `26.1.4-3.3` and fixed in `26.1.11-1.3`)

VBDs that were not snapshotted are kept after `VM.revert`

Step-by-step:
1. VM only has `xvda` VBD
2. It's snapshotted
3. Another VBD is added as `xvdb`, pointing to VDI `X`
4. VM is reverted
5. VM has `xvda` VBD (pointing to the snapshotted VDI) and still has `xvdb` (pointing to VDI `X`)

This means that the revert does not actually revert the VM to the previous state.

##### Detection and resolution

There's no 100% way to detect such "leftover" VBDs - they look just like VBDs that were created after a VM was reverted.

I've created a quick-and-dirty script ([here](https://gist.github.com/last-genius/edf7dab3b1847ec5bb1d9917996eba41)) that detects such VBDs - it's up to the user to determine what to do with them.

The script follows this algorithm:
1. Find all VMs that are children of snapshots (i.e. were reverted to a particular snapshot at some point in time)
2. Find VBDs that are currently present in such VMs but are not present in the snapshot

Example script output:
`
VM e2678368-596d-1b6e-7211-9ee45f60dec1 ("Alpine minimal for CI") has VBDs that are not present in the snapshot it was reverted to (303ead66-9515-b1c8-0dc5-d33b7644b161 "Alpine minimal for CI_2026-07-03T10:48:30.615Z"): xvdb (ca8610d2-76e3-6c54-4378-ee599619b4bb))
`

#### Documentation update needed

- [X] No

---

### Testing and regression avoidance

This PR adds a quicktest that verifies the regression has been fixed. 

#### What tests have you performed?

I've ran the quicktest added in this PR - it fails before the fix included here and passes with it

#### What manual tests should be performed after the build, and by whom?

None

#### What's covered by the xcp-ng-tests test suite?

xcp-ng-tests CI runs the xapi quicktests

#### What tests have been or will be added to CI for this change? If none, explain why.

None are added to xcp-ng-tests, but a new quicktest is indirectly picked up by the CI

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No
