### PR TITLE
Rebuild against OpenSSL 3.0

### DIFF
--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.13
-Release: 1%{?xsrel}.2%{?dist}
+Release: 1%{?xsrel}.3%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -1546,6 +1546,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Tue Aug 04 2026 Samuel Verschelde <stormi-xcp@ylix.fr> - 26.1.13-1.3
+- Rebuild against OpenSSL 3.0
+
 * Wed Jul 22 2026 Sebastien Rodot <sebastien.rodot@vates.tech> - 26.1.13-1.2
 - XCPNG-3259: Implement VLAN Filtering
 


### PR DESCRIPTION
### Main information

`XCPNG-3259`

#### Related changes (optional)

This is a rebuild of #139 against a different OpenSSL.

#### Context & Motivation

We built the previous package against OpenSSL 3.5. There wasn't necessarily an impact, but out of caution, since we moved back to OpenSSL 3.0 for the time being, we're rebuilding the few packages that had OpenSSL 3.5 in their buildroot.

#### Release Target

- [x] We already defined a release target with the release team.

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

No functional changes.

#### Attention points

N/A

#### Documentation update needed

- [ ] Yes
- [x] No
- [ ] I'm not sure, help me

---

### Testing and regression avoidance

#### What tests have you performed?

None, this is just a rebuild. Regular CI will be enough.

#### What manual tests should be performed after the build, and by whom?

See #139 

#### What's covered by the xcp-ng-tests test suite?

The usual safety net.

#### What tests have been or will be added to CI for this change? If none, explain why.

None, no functional changes.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No
