### PR TITLE
Optimize migration from QCOW2-backed VDIs + preserve VDI tags on migration

### DIFF
--- a/SOURCES/0015-ocaml-libs-Move-Vhd_qcow_parsing-into-a-library-outs.patch
+++ b/SOURCES/0015-ocaml-libs-Move-Vhd_qcow_parsing-into-a-library-outs.patch
@@ -1,0 +1,337 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Tue, 11 Aug 2026 09:17:14 +0000
+Subject: [PATCH] ocaml/libs: Move Vhd_qcow_parsing into a library outside of
+ xapi
+
+It will be used in sparse_dd, so move it to libs/vhd
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ dune-project                                  | 14 ++++++
+ ocaml/libs/vhd/vhd_qcow_parsing/dune          | 13 +++++
+ .../vhd/vhd_qcow_parsing}/vhd_qcow_parsing.ml | 42 +++++++++++++++++
+ .../vhd_qcow_parsing}/vhd_qcow_parsing.mli    |  9 +++-
+ ocaml/xapi/dune                               |  1 +
+ ocaml/xapi/qcow_tool_wrapper.ml               | 47 +++----------------
+ ocaml/xapi/qcow_tool_wrapper.mli              |  4 --
+ ocaml/xapi/stream_vdi.ml                      |  4 +-
+ opam/vhd-tool.opam                            |  1 +
+ opam/vhd_qcow_parsing.opam                    | 31 ++++++++++++
+ opam/xapi.opam                                |  1 +
+ 11 files changed, 118 insertions(+), 49 deletions(-)
+ create mode 100644 ocaml/libs/vhd/vhd_qcow_parsing/dune
+ rename ocaml/{xapi => libs/vhd/vhd_qcow_parsing}/vhd_qcow_parsing.ml (75%)
+ rename ocaml/{xapi => libs/vhd/vhd_qcow_parsing}/vhd_qcow_parsing.mli (81%)
+ create mode 100644 opam/vhd_qcow_parsing.opam
+
+diff --git a/dune-project b/dune-project
+index 09fa04faa..d7b344840 100644
+--- a/dune-project
++++ b/dune-project
+@@ -490,6 +490,8 @@
+   xmlm
+   (xml-light2
+    (= :version))
++  (vhd_qcow_parsing
++   (= :version))
+   yojson
+   (zstd
+    (= :version))))
+@@ -531,6 +533,8 @@
+    (= :version))
+   (vhd-format-lwt
+    (= :version))
++  (vhd_qcow_parsing
++   (= :version))
+   (xapi-idl
+    (= :version))
+   (xapi-log
+@@ -541,6 +545,16 @@
+   xenstore_transport
+   yojson))
+ 
++(package
++ (name vhd_qcow_parsing)
++ (synopsis "Wrapper to parse VHD and QCOW headers to determine allocated
++           clusters")
++ (depends
++  (ocaml (>= "4.13.0"))
++  dune
++ )
++)
++
+ (package
+  (name vhd-format)
+  (synopsis "Pure OCaml library to read/write VHD format data")
+diff --git a/ocaml/libs/vhd/vhd_qcow_parsing/dune b/ocaml/libs/vhd/vhd_qcow_parsing/dune
+new file mode 100644
+index 000000000..c8410ec8a
+--- /dev/null
++++ b/ocaml/libs/vhd/vhd_qcow_parsing/dune
+@@ -0,0 +1,13 @@
++(library
++  (name vhd_qcow_parsing)
++  (public_name vhd_qcow_parsing)
++  (modules vhd_qcow_parsing)
++  (libraries
++    threads.posix
++    xapi-log
++    forkexec
++    yojson
++    xapi-consts
++    xapi-stdext-pervasives
++  )
++)
+diff --git a/ocaml/xapi/vhd_qcow_parsing.ml b/ocaml/libs/vhd/vhd_qcow_parsing/vhd_qcow_parsing.ml
+similarity index 75%
+rename from ocaml/xapi/vhd_qcow_parsing.ml
+rename to ocaml/libs/vhd/vhd_qcow_parsing/vhd_qcow_parsing.ml
+index 90ed8a7b2..86540cc1b 100644
+--- a/ocaml/xapi/vhd_qcow_parsing.ml
++++ b/ocaml/libs/vhd/vhd_qcow_parsing/vhd_qcow_parsing.ml
+@@ -105,3 +105,45 @@ let parse_header_interval pipe_reader =
+     )
+   in
+   (cluster_size, cluster_list)
++
++module Qcow = struct
++  let qemu_img = "/usr/lib64/xen/bin/qemu-img"
++
++  let read_header qcow_path =
++    let progress_cb _ = () in
++    let run_in_thread tool args pipe_writer replace_fds =
++      Thread.create
++        (fun () ->
++          Xapi_stdext_pervasives.Pervasiveext.finally
++            (fun () ->
++              run_tool tool progress_cb args ~output_fd:pipe_writer ~replace_fds
++            )
++            (fun () -> Unix.close pipe_writer)
++        )
++        ()
++    in
++
++    let map_pipe_reader, map_pipe_writer = Unix.pipe ~cloexec:true () in
++    let (_ : Thread.t) =
++      run_in_thread qemu_img
++        ["map"; qcow_path; "--output=json"]
++        map_pipe_writer []
++    in
++
++    let info_pipe_reader, info_pipe_writer = Unix.pipe ~cloexec:true () in
++    let (_ : Thread.t) =
++      run_in_thread qemu_img
++        ["info"; qcow_path; "--output=json"]
++        info_pipe_writer []
++    in
++
++    (map_pipe_reader, info_pipe_reader)
++
++  let parse_header qcow_path =
++    let pipe, _ = read_header qcow_path in
++    parse_header pipe
++
++  let parse_header_interval qcow_path =
++    let pipes = read_header qcow_path in
++    parse_header_qemu_img pipes
++end
+diff --git a/ocaml/xapi/vhd_qcow_parsing.mli b/ocaml/libs/vhd/vhd_qcow_parsing/vhd_qcow_parsing.mli
+similarity index 81%
+rename from ocaml/xapi/vhd_qcow_parsing.mli
+rename to ocaml/libs/vhd/vhd_qcow_parsing/vhd_qcow_parsing.mli
+index f43b56dab..b990ea855 100644
+--- a/ocaml/xapi/vhd_qcow_parsing.mli
++++ b/ocaml/libs/vhd/vhd_qcow_parsing/vhd_qcow_parsing.mli
+@@ -25,5 +25,10 @@ val parse_header : Unix.file_descr -> int * int list
+ 
+ val parse_header_interval : Unix.file_descr -> int * (int * int) list
+ 
+-val parse_header_qemu_img :
+-  Unix.file_descr * Unix.file_descr -> int * (int * int) list
++module Qcow : sig
++  val read_header : string -> Unix.file_descr * Unix.file_descr
++
++  val parse_header : string -> int * int list
++
++  val parse_header_interval : string -> int * (int * int) list
++end
+diff --git a/ocaml/xapi/dune b/ocaml/xapi/dune
+index b2c78a30c..961d8eed1 100644
+--- a/ocaml/xapi/dune
++++ b/ocaml/xapi/dune
+@@ -195,6 +195,7 @@
+   uri
+   uuid
+   uuidm
++  vhd_qcow_parsing
+   x509
+   xapi_aux
+   xapi-backtrace
+diff --git a/ocaml/xapi/qcow_tool_wrapper.ml b/ocaml/xapi/qcow_tool_wrapper.ml
+index 652db754a..d6f05aa2a 100644
+--- a/ocaml/xapi/qcow_tool_wrapper.ml
++++ b/ocaml/xapi/qcow_tool_wrapper.ml
+@@ -21,45 +21,6 @@ let receive (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+   let qcow_tool = !Xapi_globs.qcow_stream_tool in
+   Vhd_qcow_parsing.run_tool qcow_tool progress_cb args ~input_fd:unix_fd
+ 
+-let read_header qcow_path =
+-  let progress_cb _ = () in
+-  let run_in_thread tool args pipe_writer replace_fds =
+-    Thread.create
+-      (fun () ->
+-        Xapi_stdext_pervasives.Pervasiveext.finally
+-          (fun () ->
+-            Vhd_qcow_parsing.run_tool tool progress_cb args
+-              ~output_fd:pipe_writer ~replace_fds
+-          )
+-          (fun () -> Unix.close pipe_writer)
+-      )
+-      ()
+-  in
+-
+-  let map_pipe_reader, map_pipe_writer = Unix.pipe ~cloexec:true () in
+-  let (_ : Thread.t) =
+-    run_in_thread !Xapi_globs.qemu_img
+-      ["map"; qcow_path; "--output=json"]
+-      map_pipe_writer []
+-  in
+-
+-  let info_pipe_reader, info_pipe_writer = Unix.pipe ~cloexec:true () in
+-  let (_ : Thread.t) =
+-    run_in_thread !Xapi_globs.qemu_img
+-      ["info"; qcow_path; "--output=json"]
+-      info_pipe_writer []
+-  in
+-
+-  (map_pipe_reader, info_pipe_reader)
+-
+-let parse_header qcow_path =
+-  let pipe, _ = read_header qcow_path in
+-  Vhd_qcow_parsing.parse_header pipe
+-
+-let parse_header_interval qcow_path =
+-  let pipes = read_header qcow_path in
+-  Vhd_qcow_parsing.parse_header_qemu_img pipes
+-
+ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+     (path : string) (_size : Int64.t) =
+   let qcow_of_device =
+@@ -69,7 +30,9 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+ 
+   (* If VDI is backed by QCOW, parse the header to determine nonzero clusters
+      to avoid reading all of the raw disk *)
+-  let input_fds = Result.map read_header qcow_path |> Result.to_option in
++  let input_fds =
++    Result.map Vhd_qcow_parsing.Qcow.read_header qcow_path |> Result.to_option
++  in
+ 
+   (* TODO: If VHD headers are to be consulted as well, qcow2-to-stdout
+      needs to properly account for cluster_bits. Currently QCOW2 export
+@@ -84,7 +47,9 @@ let send ?relative_to (progress_cb : int -> unit) (unix_fd : Unix.file_descr)
+     | None ->
+         None
+   in
+-  let diff_fds = Option.map read_header relative_to_qcow_path in
++  let diff_fds =
++    Option.map Vhd_qcow_parsing.Qcow.read_header relative_to_qcow_path
++  in
+ 
+   let map_fd_string = Uuidx.(to_string (make ())) in
+   let info_fd_string = Uuidx.(to_string (make ())) in
+diff --git a/ocaml/xapi/qcow_tool_wrapper.mli b/ocaml/xapi/qcow_tool_wrapper.mli
+index 16cede3bb..51c3c6265 100644
+--- a/ocaml/xapi/qcow_tool_wrapper.mli
++++ b/ocaml/xapi/qcow_tool_wrapper.mli
+@@ -23,7 +23,3 @@ val send :
+   -> string
+   -> int64
+   -> unit
+-
+-val parse_header : string -> int * int list
+-
+-val parse_header_interval : string -> int * (int * int) list
+diff --git a/ocaml/xapi/stream_vdi.ml b/ocaml/xapi/stream_vdi.ml
+index 4481cb767..641aeecf7 100644
+--- a/ocaml/xapi/stream_vdi.ml
++++ b/ocaml/xapi/stream_vdi.ml
+@@ -315,7 +315,7 @@ let send_one ofd (__context : Context.t) rpc session_id progress refresh_session
+                   | "vhd" ->
+                       Vhd_tool_wrapper.parse_header path
+                   | "qcow2" ->
+-                      Qcow_tool_wrapper.parse_header path
++                      Vhd_qcow_parsing.Qcow.parse_header path
+                   | _ ->
+                       failwith (Printf.sprintf "%s: unreachable" __FUNCTION__)
+                 in
+@@ -344,7 +344,7 @@ let send_one ofd (__context : Context.t) rpc session_id progress refresh_session
+                   | "vhd" ->
+                       Vhd_tool_wrapper.parse_header_interval path
+                   | "qcow2" ->
+-                      Qcow_tool_wrapper.parse_header_interval path
++                      Vhd_qcow_parsing.Qcow.parse_header_interval path
+                   | _ ->
+                       failwith (Printf.sprintf "%s: unreachable" __FUNCTION__)
+                 in
+diff --git a/opam/vhd-tool.opam b/opam/vhd-tool.opam
+index 0edc71774..d1f89de71 100644
+--- a/opam/vhd-tool.opam
++++ b/opam/vhd-tool.opam
+@@ -35,6 +35,7 @@ depends: [
+   "uri"
+   "vhd-format" {= version}
+   "vhd-format-lwt" {= version}
++  "vhd_qcow_parsing" {= version}
+   "xapi-idl" {= version}
+   "xapi-log" {= version}
+   "xen-api-client-lwt" {= version}
+diff --git a/opam/vhd_qcow_parsing.opam b/opam/vhd_qcow_parsing.opam
+new file mode 100644
+index 000000000..f51b3b026
+--- /dev/null
++++ b/opam/vhd_qcow_parsing.opam
+@@ -0,0 +1,31 @@
++# This file is generated by dune, edit dune-project instead
++opam-version: "2.0"
++synopsis: """
++Wrapper to parse VHD and QCOW headers to determine allocated
++           clusters"""
++maintainer: ["Xapi project maintainers"]
++authors: ["xen-api@lists.xen.org"]
++license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
++homepage: "https://xapi-project.github.io/"
++bug-reports: "https://github.com/xapi-project/xen-api/issues"
++depends: [
++  "ocaml" {>= "4.13.0"}
++  "dune" {>= "3.20"}
++  "odoc" {with-doc}
++]
++build: [
++  ["dune" "subst"] {dev}
++  [
++    "dune"
++    "build"
++    "-p"
++    name
++    "-j"
++    jobs
++    "@install"
++    "@runtest" {with-test}
++    "@doc" {with-doc}
++  ]
++]
++dev-repo: "git+https://github.com/xapi-project/xen-api.git"
++x-maintenance-intent: ["(latest)"]
+diff --git a/opam/xapi.opam b/opam/xapi.opam
+index 34dd9af3b..9af7ce8b4 100644
+--- a/opam/xapi.opam
++++ b/opam/xapi.opam
+@@ -93,6 +93,7 @@ depends: [
+   "xenstore_transport"
+   "xmlm"
+   "xml-light2" {= version}
++  "vhd_qcow_parsing" {= version}
+   "yojson"
+   "zstd" {= version}
+   "odoc" {with-doc}

--- a/SOURCES/0016-vhd-tool-Add-a-hybridqcow-mode.patch
+++ b/SOURCES/0016-vhd-tool-Add-a-hybridqcow-mode.patch
@@ -1,0 +1,227 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Wed, 12 Aug 2026 10:58:28 +0000
+Subject: [PATCH] vhd-tool: Add a hybridqcow mode
+
+This will be used if the disk has a backing qcow2 image, in which case the
+table of allocated clusters will be consulted (Vhd_qcow_parsing is used as the
+library handling this, which calls qemu-img under the hood).
+
+This means that QCOW2-backed VDIs are no longer treated as raw during migration.
+This greatly speeds up migration for sparse QCOW2-backed VDIs, since only the
+allocated clusters will now be transferred.
+
+The 'relative_to' parameter is not currently implemented for QCOW2, with the
+whole VDI transferred, not only the difference.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/libs/vhd/vhd_format/f.ml  | 43 +++++++++++++++++++++++++++++++++
+ ocaml/libs/vhd/vhd_format/f.mli |  2 ++
+ ocaml/vhd-tool/cli/sparse_dd.ml | 14 +++++++++++
+ ocaml/vhd-tool/src/dune         |  1 +
+ ocaml/vhd-tool/src/image.ml     |  9 ++++++-
+ ocaml/vhd-tool/src/image.mli    |  3 ++-
+ ocaml/vhd-tool/src/impl.ml      | 20 +++++++++++++++
+ 7 files changed, 90 insertions(+), 2 deletions(-)
+
+diff --git a/ocaml/libs/vhd/vhd_format/f.ml b/ocaml/libs/vhd/vhd_format/f.ml
+index c3bf4dce4..99a2239a9 100644
+--- a/ocaml/libs/vhd/vhd_format/f.ml
++++ b/ocaml/libs/vhd/vhd_format/f.ml
+@@ -2822,6 +2822,47 @@ functor
+                 )
+                 to_include false
+ 
++      let qcow_common raw cluster_size cluster_list =
++        let cluster_to_sector x =
++          Int64.of_int (x * cluster_size / sector_size)
++        in
++        let cluster_to_byte x = Int64.of_int (x * cluster_size) in
++        let empty_clusters x = `Empty (cluster_to_sector x) in
++        let copy_clusters offset len =
++          `Copy (raw, cluster_to_sector offset, cluster_to_sector len)
++        in
++        let rec cluster i = function
++          | (start_cluster, _) :: _ as lst when i < start_cluster ->
++              let len = start_cluster - i in
++              let next_cluster () = cluster start_cluster lst in
++              return (Cons (empty_clusters len, next_cluster))
++          | (start_cluster, end_cluster) :: tail ->
++              let len = end_cluster - start_cluster + 1 in
++              let next_cluster () = cluster (end_cluster + 1) tail in
++              return (Cons (copy_clusters start_cluster len, next_cluster))
++          | [] ->
++              return End
++        in
++        let rec count i size = function
++          | (start_cluster, _) :: _ as lst when i < start_cluster ->
++              let len = start_cluster - i in
++              let size =
++                {size with empty= Int64.(add size.empty (cluster_to_byte len))}
++              in
++              count start_cluster size lst
++          | (start_cluster, end_cluster) :: tail ->
++              let len = end_cluster - start_cluster + 1 in
++              let size =
++                {size with copy= Int64.(add size.copy (cluster_to_byte len))}
++              in
++              count (end_cluster + 1) size tail
++          | [] ->
++              size
++        in
++        let elements = cluster 0 cluster_list in
++        let size = count 0 empty cluster_list in
++        elements >>= fun elements -> return {elements; size}
++
+       let raw_common ?from ?(raw : 'a) (vhd : fd Vhd.t) =
+         let block_size_sectors_shift =
+           vhd.Vhd.header.Header.block_size_sectors_shift
+@@ -3204,6 +3245,8 @@ functor
+       let vhd ?from (raw : 'a) (vhd : fd Vhd.t) =
+         Vhd_input.vhd_common ?from ~raw vhd
+ 
++      let qcow raw qcow_info = Vhd_input.qcow_common raw qcow_info
++
+       let blocks_json = Vhd_input.vhd_blocks_to_json
+ 
+       let blocks_json_interval = Vhd_input.vhd_blocks_to_json_interval
+diff --git a/ocaml/libs/vhd/vhd_format/f.mli b/ocaml/libs/vhd/vhd_format/f.mli
+index fdeca3ad1..77c8c6d99 100644
+--- a/ocaml/libs/vhd/vhd_format/f.mli
++++ b/ocaml/libs/vhd/vhd_format/f.mli
+@@ -469,6 +469,8 @@ module From_file : functor (F : S.FILE) -> sig
+         stream will contain only the virtual updates required to transform
+         [from] into [t] *)
+ 
++    val qcow : fd -> int -> (int * int) list -> fd stream t
++
+     val blocks_json : fd Vhd.t -> unit t
+ 
+     val blocks_json_interval : fd Vhd.t -> unit t
+diff --git a/ocaml/vhd-tool/cli/sparse_dd.ml b/ocaml/vhd-tool/cli/sparse_dd.ml
+index ab8d87969..b958594a2 100644
+--- a/ocaml/vhd-tool/cli/sparse_dd.ml
++++ b/ocaml/vhd-tool/cli/sparse_dd.ml
+@@ -413,6 +413,8 @@ let _ =
+         Some x
+     | Some (`Raw _) ->
+         None
++    | Some (`Qcow _) ->
++        None (* TODO: make delta copies work with QCOW *)
+     | Some (`Nbd _) ->
+         None (* TODO: make delta copies work with NBD, CA-289660 *)
+     | None ->
+@@ -475,6 +477,18 @@ let _ =
+           Impl.make_stream common (src ^ ":" ^ vhd) relative_to "hybrid" "raw"
+         in
+         (t, dest, "raw")
++    | _, Some (`Qcow qcow), _, _ ->
++        (* experimental tapdisk bypass mode is not supported for QCOW2, assume false *)
++        let dest = rewrite_url dest in
++        info
++          "streaming from raw %s using BAT from %s (relative to %s) to raw %s"
++          src qcow (string_opt relative_to) dest ;
++        let t =
++          Impl.make_stream common
++            (src ^ ":" ^ qcow)
++            relative_to "hybridqcow" "raw"
++        in
++        (t, dest, "raw")
+     | _, Some (`Nbd (server, export_name)), _, _ ->
+         let dest = rewrite_url dest in
+         let t =
+diff --git a/ocaml/vhd-tool/src/dune b/ocaml/vhd-tool/src/dune
+index 9092e4e03..c4724901b 100644
+--- a/ocaml/vhd-tool/src/dune
++++ b/ocaml/vhd-tool/src/dune
+@@ -28,6 +28,7 @@
+     unix
+     uri
+     uuidm
++    vhd_qcow_parsing
+     vhd-format
+     vhd-format-lwt
+     tapctl
+diff --git a/ocaml/vhd-tool/src/image.ml b/ocaml/vhd-tool/src/image.ml
+index c28e50f16..2583d6e31 100644
+--- a/ocaml/vhd-tool/src/image.ml
++++ b/ocaml/vhd-tool/src/image.ml
+@@ -8,11 +8,14 @@ let is_nbd_device path =
+   let Stat.{major; _} = get_device_numbers path in
+   major = nbd_device_num
+ 
+-type t = [`Vhd of string | `Raw of string | `Nbd of string * string]
++type t =
++  [`Vhd of string | `Qcow of string | `Raw of string | `Nbd of string * string]
+ 
+ let to_string = function
+   | `Vhd x ->
+       "vhd:" ^ x
++  | `Qcow x ->
++      "qcow:" ^ x
+   | `Raw x ->
+       "raw:" ^ x
+   | `Nbd (x, y) ->
+@@ -56,6 +59,8 @@ let image_behind_nbd_device image =
+           match Tapctl.find (Tapctl.create ()) ~pid ~minor with
+           | _, _, Some ("vhd", vhd) ->
+               Some (`Vhd vhd)
++          | _, _, Some ("qcow2", qcow) ->
++              Some (`Qcow qcow)
+           | _, _, Some ("aio", vhd) ->
+               Some (`Raw vhd)
+           | _, _, _ | (exception _) ->
+@@ -68,6 +73,8 @@ let of_device path =
+   match Tapctl.of_device (Tapctl.create ()) path with
+   | Some (_, _, Some ("vhd", vhd)) ->
+       Some (`Vhd vhd)
++  | Some (_, _, Some ("qcow2", qcow)) ->
++      Some (`Qcow qcow)
+   | Some (_, _, Some ("aio", vhd)) ->
+       Some (`Raw vhd)
+   | _ ->
+diff --git a/ocaml/vhd-tool/src/image.mli b/ocaml/vhd-tool/src/image.mli
+index 439042d65..14b053283 100644
+--- a/ocaml/vhd-tool/src/image.mli
++++ b/ocaml/vhd-tool/src/image.mli
+@@ -1,6 +1,7 @@
+ (** An image may either be backed by a vhd-format file or a
+     raw-format file. *)
+-type t = [`Vhd of string | `Raw of string | `Nbd of string * string]
++type t =
++  [`Vhd of string | `Qcow of string | `Raw of string | `Nbd of string * string]
+ 
+ val to_string : t -> string
+ (** Pretty-print the image *)
+diff --git a/ocaml/vhd-tool/src/impl.ml b/ocaml/vhd-tool/src/impl.ml
+index 6c7595351..ac93b1a5c 100644
+--- a/ocaml/vhd-tool/src/impl.ml
++++ b/ocaml/vhd-tool/src/impl.ml
+@@ -878,6 +878,26 @@ let make_stream common source relative_to source_format destination_format =
+              )
+           )
+   )
++  | "hybridqcow", "raw" -> (
++    (* expect source to be block_device:qcow *)
++    match split ~limit:2 ~sep:':' source with
++    | [raw; qcow] ->
++        let cluster_size, cluster_list =
++          Vhd_qcow_parsing.Qcow.parse_header_interval qcow
++        in
++        (* TODO: respect relative_to *)
++        Vhd_format_lwt.IO.openfile raw false >>= fun raw ->
++        Hybrid_input.qcow raw cluster_size cluster_list
++    | _ ->
++        fail
++          (Failure
++             (Printf.sprintf
++                "Failed to parse hybrid source: %s (expected \
++                 raw_disk|qcow_image)"
++                source
++             )
++          )
++  )
+   | "hybrid", "vhd" -> (
+     (* expect source to be block_device:vhd *)
+     match split ~limit:2 ~sep:':' source with

--- a/SOURCES/0017-quicktest-Add-VDI.pool_migrate-tests-to-vdi_ops_data.patch
+++ b/SOURCES/0017-quicktest-Add-VDI.pool_migrate-tests-to-vdi_ops_data.patch
@@ -1,0 +1,236 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Tue, 18 Aug 2026 14:28:52 +0000
+Subject: [PATCH] quicktest: Add VDI.pool_migrate tests to
+ vdi_ops_data_integrity
+
+This verifies that pool migration preserves the contents of the VDIs, not just
+that it succeeds.
+
+The new test uses the local_vdi_migration function from Quicktest_vm_migration,
+so it's parametrized for both callers.
+
+Also migrate from qcow2, not just vhd.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+---
+ ocaml/quicktest/qt_filter.ml                  |  6 ++
+ ocaml/quicktest/qt_filter.mli                 |  6 ++
+ .../quicktest_vdi_ops_data_integrity.ml       | 65 +++++++++++++++++++
+ ocaml/quicktest/quicktest_vm_migration.ml     | 52 ++++++++-------
+ 4 files changed, 105 insertions(+), 24 deletions(-)
+
+diff --git a/ocaml/quicktest/qt_filter.ml b/ocaml/quicktest/qt_filter.ml
+index 7ff42ba9f..2dbf4676a 100644
+--- a/ocaml/quicktest/qt_filter.ml
++++ b/ocaml/quicktest/qt_filter.ml
+@@ -312,6 +312,12 @@ module SR = struct
+ 
+   let smapiv3 = sr_filter (fun i -> not (is_smapiv1 i))
+ 
++  let smapiv1_mig =
++    all |> not_iso |> smapiv1 |> allowed_operations [`vdi_mirror; `vdi_snapshot]
++
++  let smapiv3_mig =
++    all |> not_iso |> smapiv3 |> allowed_operations [`vdi_mirror]
++
+   let thin_pro =
+     sr_filter (has_one_of_types ["gfs2"; "nfs"; "smb"; "ext"; "file"])
+ 
+diff --git a/ocaml/quicktest/qt_filter.mli b/ocaml/quicktest/qt_filter.mli
+index 92f7bc366..8d2aec5f5 100644
+--- a/ocaml/quicktest/qt_filter.mli
++++ b/ocaml/quicktest/qt_filter.mli
+@@ -79,6 +79,12 @@ module SR : sig
+   val smapiv3 : srs -> srs
+   (** Selects SMAPIv3 SRs *)
+ 
++  val smapiv1_mig : srs
++  (** Selects SMAPIv1 SRs that support migration *)
++
++  val smapiv3_mig : srs
++  (** Selects SMAPIv3 SRs that support migration *)
++
+   val thin_pro : srs -> srs
+   (** Selects thinly-provisioned SRs *)
+ 
+diff --git a/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml b/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
+index b9d254868..6a205e253 100644
+--- a/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
++++ b/ocaml/quicktest/quicktest_vdi_ops_data_integrity.ml
+@@ -77,6 +77,27 @@ let check_vdi_unchanged rpc session_id ~vdi_size ~prepare_vdi ~vdi_op
+       )
+   )
+ 
++let check_vdi_unchanged_migration rpc session_id ~vdi_size ~prepare_vdi
++    ~backing_format vm sr_infos () =
++  let checksum_original = ref "" in
++  let prepare_vdi vdi =
++    prepare_vdi rpc session_id vdi ;
++    checksum_original := checksum rpc session_id vdi
++  in
++  let post_migration vdi =
++    let checksum_copy = checksum rpc session_id vdi in
++    if checksum_copy <> !checksum_original then
++      failwith
++        (Printf.sprintf
++           "New VDI (checksum: %s) has different data than original (checksum: \
++            %s)."
++           checksum_copy !checksum_original
++        )
++  in
++  Quicktest_vm_migration.local_vdi_migration ~backing_format
++    ~virtual_size:vdi_size ~prepare_vdi ~post_migration rpc session_id vm
++    sr_infos ()
++
+ let check_vdi_delta rpc session_id ~vdi_size ~prepare_vdi ~prepare_vdi_base
+     ~vdi_op ~backing_format sr_info () =
+   let sR = sr_info.Qt.sr in
+@@ -204,6 +225,41 @@ let data_integrity_tests vdi_op op_name backing_format =
+     )
+   ]
+ 
++let migration_data_integrity_tests backing_format =
++  let op_name = Printf.sprintf "VDI.pool_migrate from %s" backing_format in
++  [
++    ( op_name ^ ": small empty VDI"
++    , `Slow
++    , check_vdi_unchanged_migration
++        ~vdi_size:Sizes.(4L ** mib)
++        ~prepare_vdi:noop ~backing_format
++    )
++  ; ( op_name ^ ": small random VDI"
++    , `Slow
++    , check_vdi_unchanged_migration
++        ~vdi_size:Sizes.(4L ** mib)
++        ~prepare_vdi:write_random_data ~backing_format
++    )
++  ; ( op_name ^ ": small full VDI"
++    , `Slow
++    , check_vdi_unchanged_migration
++        ~vdi_size:Sizes.(4L ** mib)
++        ~prepare_vdi:fill ~backing_format
++    )
++  ; ( op_name ^ ": ~2GiB empty VDI"
++    , `Slow
++    , check_vdi_unchanged_migration
++        ~vdi_size:Sizes.(2L ** gib)
++        ~prepare_vdi:noop ~backing_format
++    )
++  ; ( op_name ^ ": ~2GiB random VDI"
++    , `Slow
++    , check_vdi_unchanged_migration
++        ~vdi_size:Sizes.(2L ** gib)
++        ~prepare_vdi:write_random_data ~backing_format
++    )
++  ]
++
+ let delta_data_integrity_tests vdi_op op_name backing_format =
+   [
+     ( op_name ^ ": delta between empty & empty VDI"
+@@ -274,6 +330,13 @@ let supported_gfs2_srs test_case =
+   let open Qt_filter in
+   test_case |> conn |> sr (sr_with_vdi_create_destroy |> SR.has_type "gfs2")
+ 
++let supported_migration_srs test_case =
++  let open Qt_filter in
++  test_case
++  |> conn
++  |> vm_template Qt.VM.Template.other
++  |> migration_path SR.smapiv1_mig
++
+ let tests () =
+   (data_integrity_tests copy_vdi "VDI.copy" "vhd" |> supported_srs)
+   @ (large_data_integrity_tests copy_vdi "VDI.copy" "vhd" |> supported_srs)
+@@ -305,3 +368,5 @@ let tests () =
+        "VDI export/import to/from TAR file" "vhd"
+     |> supported_gfs2_srs
+     )
++  @ (migration_data_integrity_tests "vhd" |> supported_migration_srs)
++  @ (migration_data_integrity_tests "qcow2" |> supported_migration_srs)
+diff --git a/ocaml/quicktest/quicktest_vm_migration.ml b/ocaml/quicktest/quicktest_vm_migration.ml
+index 6738cf724..96b036979 100644
+--- a/ocaml/quicktest/quicktest_vm_migration.ml
++++ b/ocaml/quicktest/quicktest_vm_migration.ml
+@@ -1,4 +1,5 @@
+-let local_vdi_migration rpc session_id vm_template
++let local_vdi_migration ?backing_format ~virtual_size ~prepare_vdi
++    ~post_migration rpc session_id vm_template
+     ((src_sr_info, dst_sr_info) : Qt.sr_info * Qt.sr_info) () =
+   let open Client in
+   Printf.printf "Testing migration from %s to %s\n"
+@@ -6,12 +7,11 @@ let local_vdi_migration rpc session_id vm_template
+     (Client.SR.get_name_label ~rpc ~session_id ~self:dst_sr_info.sr) ;
+ 
+   (* Create a VDI on src *)
+-  let vdi =
+-    Client.VDI.create ~rpc ~session_id ~name_label:"[QT] testing migration"
+-      ~name_description:__FILE__ ~sR:src_sr_info.sr ~virtual_size:2097152L
+-      ~_type:`user ~sharable:false ~read_only:false ~other_config:[]
+-      ~xenstore_data:[] ~sm_config:[] ~tags:[]
+-  in
++  Qt.VDI.with_new ~name_label:"[QT] testing migration"
++    ~name_description:__FILE__ ~virtual_size ?backing_format rpc session_id
++    src_sr_info.sr
++  @@ fun vdi ->
++  prepare_vdi vdi ;
+ 
+   (* Track which VDI must be destroyed at cleanup time. After migration, ownership
+      moves from the original VDI to the migrated one. *)
+@@ -43,7 +43,9 @@ let local_vdi_migration rpc session_id vm_template
+           in
+ 
+           Alcotest.(check string)
+-            "VDI migrated to destination SR" expected actual
++            "VDI migrated to destination SR" expected actual ;
++
++          post_migration migrated_vdi
+       )
+     )
+     (fun () ->
+@@ -51,27 +53,29 @@ let local_vdi_migration rpc session_id vm_template
+     )
+ 
+ let tests () =
+-  let smapiv1_mig =
+-    Qt_filter.SR.(
+-      all
+-      |> not_iso
+-      |> smapiv1
+-      |> allowed_operations [`vdi_mirror; `vdi_snapshot]
+-    )
+-  in
+-  let smapiv3_mig =
+-    Qt_filter.SR.(all |> not_iso |> smapiv3 |> allowed_operations [`vdi_mirror])
+-  in
+-
++  let prepare_vdi = fun _ -> () in
++  let post_migration = fun _ -> () in
+   let open Qt_filter in
+   [
+-    [("SMAPIv1 migration test", `Slow, local_vdi_migration)]
++    [
++      ( "SMAPIv1 migration test"
++      , `Slow
++      , local_vdi_migration ~backing_format:"vhd" ~virtual_size:2097152L
++          ~prepare_vdi ~post_migration
++      )
++    ]
+     |> conn
+     |> vm_template Qt.VM.Template.other
+-    |> migration_path smapiv1_mig
+-  ; [("SMAPIv3 migration test", `Slow, local_vdi_migration)]
++    |> migration_path SR.smapiv1_mig
++  ; [
++      ( "SMAPIv3 migration test"
++      , `Slow
++      , local_vdi_migration ~backing_format:"vhd" ~virtual_size:2097152L
++          ~prepare_vdi ~post_migration
++      )
++    ]
+     |> conn
+     |> vm_template Qt.VM.Template.other
+-    |> migration_path smapiv3_mig
++    |> migration_path SR.smapiv3_mig
+   ]
+   |> List.concat

--- a/SOURCES/0018-storage-Add-tags-to-vdi_info-struct.patch
+++ b/SOURCES/0018-storage-Add-tags-to-vdi_info-struct.patch
@@ -1,0 +1,182 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 18 May 2026 13:04:20 +0000
+Subject: [PATCH] storage: Add tags to vdi_info struct
+
+This is the first step towards allowing SMAPIv1/v3 code to preserve tags
+on VDI migrations.
+
+Also modifies the tests by adding the new 'tags' field.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+(cherry picked from commit 51b30303a041ce969e874d15d0e1569f524ee207)
+---
+ ocaml/xapi-idl/storage/storage_interface.ml               | 1 +
+ ocaml/xapi-storage-script/main.ml                         | 2 ++
+ ocaml/xapi-storage-script/python-self-test.t              | 8 ++++----
+ .../test/volume/org.xen.xapi.storage.dummyv5/sr.py        | 1 +
+ .../test/volume/org.xen.xapi.storage.dummyv5/volume.py    | 2 ++
+ ocaml/xapi-storage/rpc-light/SR.ls/response               | 1 +
+ ocaml/xapi-storage/rpc-light/Volume.clone/response        | 1 +
+ ocaml/xapi-storage/rpc-light/Volume.create/response       | 1 +
+ ocaml/xapi-storage/rpc-light/Volume.snapshot/response     | 1 +
+ ocaml/xapi/storage_smapiv1.ml                             | 1 +
+ 10 files changed, 15 insertions(+), 4 deletions(-)
+
+diff --git a/ocaml/xapi-idl/storage/storage_interface.ml b/ocaml/xapi-idl/storage/storage_interface.ml
+index ebcf64276..f2a88379a 100644
+--- a/ocaml/xapi-idl/storage/storage_interface.ml
++++ b/ocaml/xapi-idl/storage/storage_interface.ml
+@@ -231,6 +231,7 @@ type vdi_info = {
+     persistent: bool [@default true]
+   ; sharable: bool [@default false]
+   ; sm_config: (string * string) list [@default []]
++  ; tags: string list [@default []]
+ }
+ [@@deriving rpcty]
+ 
+diff --git a/ocaml/xapi-storage-script/main.ml b/ocaml/xapi-storage-script/main.ml
+index 97e020be6..b24d6ba6a 100644
+--- a/ocaml/xapi-storage-script/main.ml
++++ b/ocaml/xapi-storage-script/main.ml
+@@ -777,6 +777,7 @@ let vdi_of_volume x =
+         x.Xapi_storage.Control.keys
+   ; sharable= x.Xapi_storage.Control.sharable
+   ; persistent= true
++  ; tags= []
+   }
+ 
+ let choose_datapath ?(persistent = true) response =
+@@ -2173,6 +2174,7 @@ let self_test_plugin ~root_dir plugin =
+         ; persistent= false
+         ; sm_config= []
+         ; sharable= false
++        ; tags= []
+         }
+       in
+       Test.VDI.create rpc dbg sr vdi_info >>= fun vdi_info ->
+diff --git a/ocaml/xapi-storage-script/python-self-test.t b/ocaml/xapi-storage-script/python-self-test.t
+index 7be4876c6..4741e4f58 100644
+--- a/ocaml/xapi-storage-script/python-self-test.t
++++ b/ocaml/xapi-storage-script/python-self-test.t
+@@ -21,16 +21,16 @@ pids and uuids
+   [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/SR.stat[PID] succeeded: {"sr": "file:///tmp/dummy", "name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "total_space": 0, "free_space": 0, "datasources": [], "clustered": false, "health": ["Healthy", ""]}
+   
+   [INFO] {"method":"Volume.create","params":[{"sharable":false,"size":0,"description":"vdi description","name":"vdi name","sr":"file:///tmp/dummy","dbg":"debug"}],"id":12}
+-  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.create[PID] succeeded: {"name": "vdi name", "description": "vdi description", "key": "UUID", "uuid": "UUID", "read_write": true, "sharable": false, "virtual_size": 0, "physical_utilisation": 0, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}}
++  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.create[PID] succeeded: {"name": "vdi name", "description": "vdi description", "key": "UUID", "uuid": "UUID", "read_write": true, "sharable": false, "virtual_size": 0, "physical_utilisation": 0, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}, "tags": ["tag1"]}
+   
+   [INFO] {"method":"Volume.set","params":[{"v":"redolog","k":"vdi-type","key":"UUID","sr":"file:///tmp/dummy","dbg":"debug"}],"id":13}
+   [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.set[PID] succeeded: null
+   
+   [INFO] {"method":"Volume.stat","params":[{"key":"UUID","sr":"file:///tmp/dummy","dbg":"debug"}],"id":15}
+-  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.stat[PID] succeeded: {"name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "key": "UUID", "uuid": "UUID", "read_write": true, "virtual_size": 0, "physical_utilisation": 0, "sharable": false, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}}
++  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.stat[PID] succeeded: {"name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "key": "UUID", "uuid": "UUID", "read_write": true, "virtual_size": 0, "physical_utilisation": 0, "sharable": false, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}, "tags": ["tag1"]}
+   
+   [INFO] {"method":"Volume.stat","params":[{"key":"UUID","sr":"file:///tmp/dummy","dbg":"debug"}],"id":17}
+-  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.stat[PID] succeeded: {"name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "key": "UUID", "uuid": "UUID", "read_write": true, "virtual_size": 0, "physical_utilisation": 0, "sharable": false, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}}
++  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.stat[PID] succeeded: {"name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "key": "UUID", "uuid": "UUID", "read_write": true, "virtual_size": 0, "physical_utilisation": 0, "sharable": false, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}, "tags": ["tag1"]}
+   
+   [INFO] {"method":"Volume.destroy","params":[{"key":"UUID","sr":"file:///tmp/dummy","dbg":"debug"}],"id":18}
+   [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/Volume.destroy[PID] succeeded: null
+@@ -39,7 +39,7 @@ pids and uuids
+   [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/SR.stat[PID] succeeded: {"sr": "file:///tmp/dummy", "name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "total_space": 0, "free_space": 0, "datasources": [], "clustered": false, "health": ["Healthy", ""]}
+   
+   [INFO] {"method":"SR.ls","params":[{"sr":"file:///tmp/dummy","dbg":"debug"}],"id":22}
+-  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/SR.ls[PID] succeeded: [{"name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "key": "file1", "uuid": "file1", "read_write": true, "virtual_size": 0, "physical_utilisation": 0, "sharable": false, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}}]
++  [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/SR.ls[PID] succeeded: [{"name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "key": "file1", "uuid": "file1", "read_write": true, "virtual_size": 0, "physical_utilisation": 0, "sharable": false, "uri": ["raw+file:///tmp/disk.raw"], "keys": {}, "tags": ["tag1"]}]
+   
+   [INFO] {"method":"SR.probe","params":[{"configuration":{"uri":"file:///tmp/dummy"},"dbg":"debug"}],"id":24}
+   [INFO] $TESTCASE_ROOT/test/volume/org.xen.xapi.storage.dummyv5/SR.probe[PID] succeeded: [{"configuration": {"uri": "file:///tmp/dummy"}, "complete": true, "extra_info": {}}, {"configuration": {"uri": "file:///tmp/dummy", "sr_uuid": "myuuid"}, "sr": {"sr": "file:///tmp/dummy", "name": "dummy SR plugin", "description": "Dummy v5 SR for unit tests.", "total_space": 0, "free_space": 0, "datasources": [], "clustered": false, "health": ["Healthy", ""]}, "complete": true, "extra_info": {}}]
+diff --git a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
+index 3c649423d..9667a7886 100755
+--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
++++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/sr.py
+@@ -39,6 +39,7 @@ class Implementation(xapi.storage.api.v5.volume.SR_skeleton):
+             "sharable": False,
+             "uri": ["raw+file:///tmp/disk.raw"],
+             "keys": {},
++            "tags": ["tag1"],
+             }]
+ 
+     def stat(self, dbg, sr):
+diff --git a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
+index fcf52ce38..13f22794a 100755
+--- a/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
++++ b/ocaml/xapi-storage-script/test/volume/org.xen.xapi.storage.dummyv5/volume.py
+@@ -30,6 +30,7 @@ class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
+             "physical_utilisation": 0,
+             "uri": ["raw+file:///tmp/disk.raw"],
+             "keys": {},
++            "tags": ["tag1"],
+         }
+ 
+     def destroy(self, dbg, sr, key):
+@@ -50,6 +51,7 @@ class Implementation(xapi.storage.api.v5.volume.Volume_skeleton):
+                 "sharable": False,
+                 "uri": ["raw+file:///tmp/disk.raw"],
+                 "keys": {},
++                "tags": ["tag1"],
+         }
+ 
+     def set(self, dbg, sr, key, k, v):
+diff --git a/ocaml/xapi-storage/rpc-light/SR.ls/response b/ocaml/xapi-storage/rpc-light/SR.ls/response
+index 7f989e330..b3ca5475f 100644
+--- a/ocaml/xapi-storage/rpc-light/SR.ls/response
++++ b/ocaml/xapi-storage/rpc-light/SR.ls/response
+@@ -14,6 +14,7 @@
+                                                             <member><name>keys</name><value><struct></struct></value></member>
+                                                             <member><name>volume_type</name><value>Data</value></member>
+                                                             <member><name>cbt_enabled</name><value>false</value></member>
++                                                            <member><name>tags</name><value><array><data><value>tag1</value></data></array></value></member>
+                                        </struct></value></data>
+                                   </array></value></member>
+     </struct></value></param></params>
+diff --git a/ocaml/xapi-storage/rpc-light/Volume.clone/response b/ocaml/xapi-storage/rpc-light/Volume.clone/response
+index dc4036f59..f6b23b83f 100644
+--- a/ocaml/xapi-storage/rpc-light/Volume.clone/response
++++ b/ocaml/xapi-storage/rpc-light/Volume.clone/response
+@@ -13,6 +13,7 @@
+                                                          <member><name>keys</name><value><struct></struct></value></member>
+                                                          <member><name>volume_type</name><value>Data</value></member>
+                                                          <member><name>cbt_enabled</name><value>false</value></member>
++                                                         <member><name>tags</name><value><array><data><value>tag1</value></data></array></value></member>
+                                          </struct>
+                                  </value></member>
+    </struct></value></param>
+diff --git a/ocaml/xapi-storage/rpc-light/Volume.create/response b/ocaml/xapi-storage/rpc-light/Volume.create/response
+index dc4036f59..f6b23b83f 100644
+--- a/ocaml/xapi-storage/rpc-light/Volume.create/response
++++ b/ocaml/xapi-storage/rpc-light/Volume.create/response
+@@ -13,6 +13,7 @@
+                                                          <member><name>keys</name><value><struct></struct></value></member>
+                                                          <member><name>volume_type</name><value>Data</value></member>
+                                                          <member><name>cbt_enabled</name><value>false</value></member>
++                                                         <member><name>tags</name><value><array><data><value>tag1</value></data></array></value></member>
+                                          </struct>
+                                  </value></member>
+    </struct></value></param>
+diff --git a/ocaml/xapi-storage/rpc-light/Volume.snapshot/response b/ocaml/xapi-storage/rpc-light/Volume.snapshot/response
+index dc4036f59..f6b23b83f 100644
+--- a/ocaml/xapi-storage/rpc-light/Volume.snapshot/response
++++ b/ocaml/xapi-storage/rpc-light/Volume.snapshot/response
+@@ -13,6 +13,7 @@
+                                                          <member><name>keys</name><value><struct></struct></value></member>
+                                                          <member><name>volume_type</name><value>Data</value></member>
+                                                          <member><name>cbt_enabled</name><value>false</value></member>
++                                                         <member><name>tags</name><value><array><data><value>tag1</value></data></array></value></member>
+                                          </struct>
+                                  </value></member>
+    </struct></value></param>
+diff --git a/ocaml/xapi/storage_smapiv1.ml b/ocaml/xapi/storage_smapiv1.ml
+index 6d4169169..c5cde919f 100644
+--- a/ocaml/xapi/storage_smapiv1.ml
++++ b/ocaml/xapi/storage_smapiv1.ml
+@@ -80,6 +80,7 @@ let vdi_info_of_vdi_rec __context vdi_rec =
+   ; persistent= vdi_rec.API.vDI_on_boot = `persist
+   ; sharable= vdi_rec.API.vDI_sharable
+   ; sm_config= vdi_rec.API.vDI_sm_config
++  ; tags= vdi_rec.API.vDI_tags
+   }
+ 
+ let redirect _sr =

--- a/SOURCES/0019-storage-Add-VDI.-add_tags-remove_tags-methods.patch
+++ b/SOURCES/0019-storage-Add-VDI.-add_tags-remove_tags-methods.patch
@@ -1,0 +1,244 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 18 May 2026 13:13:05 +0000
+Subject: [PATCH] storage: Add VDI.{add_tags,remove_tags} methods
+
+This allows for the storage backend to preserve tags after creating a
+destination VDI during migration.
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+(cherry picked from commit 42cb9bd2e06cc579eeb02af0e2c6ad455586b2ad)
+---
+ ocaml/xapi-idl/storage/storage_interface.ml | 22 +++++++++++++
+ ocaml/xapi-idl/storage/storage_skeleton.ml  |  6 ++++
+ ocaml/xapi-storage-script/main.ml           | 35 ++++++++++++++++++++-
+ ocaml/xapi/storage_mux.ml                   | 18 +++++++++++
+ ocaml/xapi/storage_smapiv1.ml               | 22 +++++++++++++
+ ocaml/xapi/storage_smapiv1_wrapper.ml       | 14 +++++++++
+ 6 files changed, 116 insertions(+), 1 deletion(-)
+
+diff --git a/ocaml/xapi-idl/storage/storage_interface.ml b/ocaml/xapi-idl/storage/storage_interface.ml
+index f2a88379a..94c2bec77 100644
+--- a/ocaml/xapi-idl/storage/storage_interface.ml
++++ b/ocaml/xapi-idl/storage/storage_interface.ml
+@@ -1002,6 +1002,16 @@ module StorageAPI (R : RPC) = struct
+       declare "VDI.remove_from_sm_config" []
+         (dbg_p @-> sr_p @-> vdi_p @-> key_p @-> returning unit_p err)
+ 
++    (** [add_tags] task sr vdi key value] adds [key] to [vdi] tags *)
++    let add_tags =
++      declare "VDI.add_tags" []
++        (dbg_p @-> sr_p @-> vdi_p @-> key_p @-> returning unit_p err)
++
++    (** [remove_tags dbg sr vdi key] removes [key] from [vdi] tags *)
++    let remove_tags =
++      declare "VDI.remove_tags" []
++        (dbg_p @-> sr_p @-> vdi_p @-> key_p @-> returning unit_p err)
++
+     (** [enable_cbt dbg sr vdi] enables changed block tracking for [vdi] *)
+     let enable_cbt =
+       declare "VDI.enable_cbt" []
+@@ -1649,6 +1659,12 @@ module type Server_impl = sig
+     val remove_from_sm_config :
+       context -> dbg:debug_info -> sr:sr -> vdi:vdi -> key:string -> unit
+ 
++    val add_tags :
++      context -> dbg:debug_info -> sr:sr -> vdi:vdi -> key:string -> unit
++
++    val remove_tags :
++      context -> dbg:debug_info -> sr:sr -> vdi:vdi -> key:string -> unit
++
+     val enable_cbt : context -> dbg:debug_info -> sr:sr -> vdi:vdi -> unit
+ 
+     val disable_cbt : context -> dbg:debug_info -> sr:sr -> vdi:vdi -> unit
+@@ -1857,6 +1873,12 @@ module Server (Impl : Server_impl) () = struct
+     S.VDI.remove_from_sm_config (fun dbg sr vdi key ->
+         Impl.VDI.remove_from_sm_config () ~dbg ~sr ~vdi ~key
+     ) ;
++    S.VDI.add_tags (fun dbg sr vdi key ->
++        Impl.VDI.add_tags () ~dbg ~sr ~vdi ~key
++    ) ;
++    S.VDI.remove_tags (fun dbg sr vdi key ->
++        Impl.VDI.remove_tags () ~dbg ~sr ~vdi ~key
++    ) ;
+     S.VDI.enable_cbt (fun dbg sr vdi -> Impl.VDI.enable_cbt () ~dbg ~sr ~vdi) ;
+     S.VDI.disable_cbt (fun dbg sr vdi -> Impl.VDI.disable_cbt () ~dbg ~sr ~vdi) ;
+     S.VDI.data_destroy (fun dbg sr vdi -> Impl.VDI.data_destroy () ~dbg ~sr ~vdi) ;
+diff --git a/ocaml/xapi-idl/storage/storage_skeleton.ml b/ocaml/xapi-idl/storage/storage_skeleton.ml
+index dbe155272..e92e30024 100644
+--- a/ocaml/xapi-idl/storage/storage_skeleton.ml
++++ b/ocaml/xapi-idl/storage/storage_skeleton.ml
+@@ -164,6 +164,12 @@ module VDI = struct
+   let remove_from_sm_config ctx ~dbg ~sr ~vdi ~key =
+     Storage_interface.unimplemented __FUNCTION__
+ 
++  let add_tags ctx ~dbg ~sr ~vdi ~key =
++    Storage_interface.unimplemented __FUNCTION__
++
++  let remove_tags ctx ~dbg ~sr ~vdi ~key =
++    Storage_interface.unimplemented __FUNCTION__
++
+   let enable_cbt ctx ~dbg ~sr ~vdi =
+     Storage_interface.unimplemented __FUNCTION__
+ 
+diff --git a/ocaml/xapi-storage-script/main.ml b/ocaml/xapi-storage-script/main.ml
+index b24d6ba6a..10ca7689f 100644
+--- a/ocaml/xapi-storage-script/main.ml
++++ b/ocaml/xapi-storage-script/main.ml
+@@ -367,6 +367,8 @@ let _is_a_snapshot_key = "is_a_snapshot"
+ 
+ let _snapshot_of_key = "snapshot_of"
+ 
++let _vdi_tags_key = "tags"
++
+ module Script = struct
+   (** We cache (lowercase script name -> original script name) mapping for the
+       scripts in the root directory of every registered plugin. *)
+@@ -740,6 +742,19 @@ let vdi_of_volume x =
+         v |> of_string
+   in
+   let find_string = find ~of_string:Fun.id in
++  let extract_prefixed_list prefix =
++    List.filter_map
++      (fun (k, _) ->
++        if String.starts_with ~prefix k then
++          Some
++            (String.sub k (String.length prefix)
++               (String.length k - String.length prefix)
++            )
++        else
++          None
++      )
++      x.Xapi_storage.Control.keys
++  in
+   let open Storage_interface in
+   {
+     vdi= Vdi.of_string x.Xapi_storage.Control.key
+@@ -777,7 +792,7 @@ let vdi_of_volume x =
+         x.Xapi_storage.Control.keys
+   ; sharable= x.Xapi_storage.Control.sharable
+   ; persistent= true
+-  ; tags= []
++  ; tags= extract_prefixed_list _vdi_tags_key
+   }
+ 
+ let choose_datapath ?(persistent = true) response =
+@@ -1758,6 +1773,22 @@ module VDIImpl (M : META) = struct
+     let* () = unset ~dbg ~sr ~vdi ~key:(_sm_config_prefix_key ^ key) in
+     return ()
+ 
++  let vdi_add_tags_impl dbg sr vdi key =
++    wrap
++    @@
++    let* sr = Attached_SRs.find sr in
++    let vdi = Storage_interface.Vdi.string_of vdi in
++    let* () = set ~dbg ~sr ~vdi ~key:(_vdi_tags_key ^ key) ~value:key in
++    return ()
++
++  let vdi_remove_tags_impl dbg sr vdi key =
++    wrap
++    @@
++    let* sr = Attached_SRs.find sr in
++    let vdi = Storage_interface.Vdi.string_of vdi in
++    let* () = unset ~dbg ~sr ~vdi ~key:(_vdi_tags_key ^ key) in
++    return ()
++
+   let similar_content_impl _dbg _sr _vdi = wrap @@ return []
+ end
+ 
+@@ -1966,6 +1997,8 @@ let bind ~volume_script_dir =
+   S.VDI.set_content_id VDI.vdi_set_content_id_impl ;
+   S.VDI.add_to_sm_config VDI.vdi_add_to_sm_config_impl ;
+   S.VDI.remove_from_sm_config VDI.vdi_remove_from_sm_config_impl ;
++  S.VDI.add_tags VDI.vdi_add_tags_impl ;
++  S.VDI.remove_tags VDI.vdi_remove_tags_impl ;
+   S.VDI.similar_content VDI.similar_content_impl ;
+   S.VDI.revert VDI.revert_impl ;
+ 
+diff --git a/ocaml/xapi/storage_mux.ml b/ocaml/xapi/storage_mux.ml
+index 7c16b56b4..e007d279c 100644
+--- a/ocaml/xapi/storage_mux.ml
++++ b/ocaml/xapi/storage_mux.ml
+@@ -741,6 +741,24 @@ module Mux = struct
+       end)) in
+       C.VDI.remove_from_sm_config (Debug_info.to_string di) sr vdi key
+ 
++    let add_tags () ~dbg ~sr ~vdi ~key =
++      with_dbg ~name:"VDI.add_tags" ~dbg @@ fun di ->
++      info "VDI.add_tags dbg:%s sr:%s vdi:%s key:%s" dbg (s_of_sr sr)
++        (s_of_vdi vdi) key ;
++      let module C = StorageAPI (Idl.Exn.GenClient (struct
++        let rpc = of_sr sr
++      end)) in
++      C.VDI.add_tags (Debug_info.to_string di) sr vdi key
++
++    let remove_tags () ~dbg ~sr ~vdi ~key =
++      with_dbg ~name:"VDI.remove_tags" ~dbg @@ fun di ->
++      info "VDI.remove_tags dbg:%s sr:%s vdi:%s key:%s" dbg (s_of_sr sr)
++        (s_of_vdi vdi) key ;
++      let module C = StorageAPI (Idl.Exn.GenClient (struct
++        let rpc = of_sr sr
++      end)) in
++      C.VDI.remove_tags (Debug_info.to_string di) sr vdi key
++
+     let get_url () ~dbg ~sr ~vdi =
+       with_dbg ~name:"VDI.get_url" ~dbg @@ fun di ->
+       info "VDI.get_url dbg:%s sr:%s vdi:%s" dbg (s_of_sr sr) (s_of_vdi vdi) ;
+diff --git a/ocaml/xapi/storage_smapiv1.ml b/ocaml/xapi/storage_smapiv1.ml
+index c5cde919f..9a859e88d 100644
+--- a/ocaml/xapi/storage_smapiv1.ml
++++ b/ocaml/xapi/storage_smapiv1.ml
+@@ -1052,6 +1052,28 @@ module SMAPIv1 : Server_impl = struct
+           Db.VDI.remove_from_sm_config ~__context ~self ~key
+       )
+ 
++    let add_tags _context ~dbg ~sr ~vdi ~key =
++      with_dbg ~name:"VDI.add_to_tags" ~dbg @@ fun di ->
++      info "VDI.add_tags dbg:%s sr:%s vdi:%s key:[%s]" di.log (s_of_sr sr)
++        (s_of_vdi vdi) key ;
++      let dbg = Debug_info.to_string di in
++      Server_helpers.exec_with_new_task "VDI.add_tags"
++        ~subtask_of:(Ref.of_string dbg) (fun __context ->
++          let vdi, _ = find_vdi ~__context sr vdi in
++          Db.VDI.add_tags ~__context ~self:vdi ~value:key
++      )
++
++    let remove_tags _context ~dbg ~sr ~vdi ~key =
++      with_dbg ~name:"VDI.remove_tags" ~dbg @@ fun di ->
++      info "VDI.remove_tags dbg:%s sr:%s vdi:%s key:%s" di.log (s_of_sr sr)
++        (s_of_vdi vdi) key ;
++      let dbg = Debug_info.to_string di in
++      Server_helpers.exec_with_new_task "VDI.remove_tags"
++        ~subtask_of:(Ref.of_string dbg) (fun __context ->
++          let self = find_vdi ~__context sr vdi |> fst in
++          Db.VDI.remove_tags ~__context ~self ~value:key
++      )
++
+     let get_url _context ~dbg ~sr ~vdi =
+       with_dbg ~name:"VDI.get_url" ~dbg @@ fun di ->
+       info "VDI.get_url dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr) (s_of_vdi vdi) ;
+diff --git a/ocaml/xapi/storage_smapiv1_wrapper.ml b/ocaml/xapi/storage_smapiv1_wrapper.ml
+index ff9611099..c344f1d25 100644
+--- a/ocaml/xapi/storage_smapiv1_wrapper.ml
++++ b/ocaml/xapi/storage_smapiv1_wrapper.ml
+@@ -915,6 +915,20 @@ functor
+         let dbg = Debug_info.to_string di in
+         Impl.VDI.remove_from_sm_config context ~dbg ~sr ~vdi ~key
+ 
++      let add_tags context ~dbg ~sr ~vdi ~key =
++        with_dbg ~name:"VDI.add_tags" ~dbg @@ fun di ->
++        info "VDI.add_tags dbg:%s sr:%s vdi:%s key:%s" di.log (s_of_sr sr)
++          (s_of_vdi vdi) key ;
++        let dbg = Debug_info.to_string di in
++        Impl.VDI.add_tags context ~dbg ~sr ~vdi ~key
++
++      let remove_tags context ~dbg ~sr ~vdi ~key =
++        with_dbg ~name:"VDI.remove_tags" ~dbg @@ fun di ->
++        info "VDI.remove_tags dbg:%s sr:%s vdi:%s key:%s" di.log (s_of_sr sr)
++          (s_of_vdi vdi) key ;
++        let dbg = Debug_info.to_string di in
++        Impl.VDI.remove_tags context ~dbg ~sr ~vdi ~key
++
+       let get_url context ~dbg ~sr ~vdi =
+         with_dbg ~name:"VDI.get_url" ~dbg @@ fun di ->
+         info "VDI.get_url dbg:%s sr:%s vdi:%s" di.log (s_of_sr sr) (s_of_vdi vdi) ;

--- a/SOURCES/0020-storage-Preserve-VDI-tags-on-SMAPIv1-migrate.patch
+++ b/SOURCES/0020-storage-Preserve-VDI-tags-on-SMAPIv1-migrate.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrii Sultanov <andriy.sultanov@vates.tech>
+Date: Mon, 18 May 2026 13:13:33 +0000
+Subject: [PATCH] storage: Preserve VDI tags on SMAPIv1 migrate
+
+SMAPI.VDI.create ignores the tags from vdi_info, so set them after the call
+
+Signed-off-by: Andrii Sultanov <andriy.sultanov@vates.tech>
+(cherry picked from commit 76c7e267da596ba4a527457c318ce81f19b38ef4)
+---
+ ocaml/xapi-storage-script/main.ml     | 8 ++++++++
+ ocaml/xapi/storage_smapiv1_migrate.ml | 5 +++++
+ 2 files changed, 13 insertions(+)
+
+diff --git a/ocaml/xapi-storage-script/main.ml b/ocaml/xapi-storage-script/main.ml
+index 10ca7689f..1b72d5a8f 100644
+--- a/ocaml/xapi-storage-script/main.ml
++++ b/ocaml/xapi-storage-script/main.ml
+@@ -1479,6 +1479,14 @@ module VDIImpl (M : META) = struct
+     set ~dbg ~sr ~vdi:response.Xapi_storage.Control.key ~key:_vdi_type_key
+       ~value:vdi_info.ty
+     >>>= fun () ->
++    let rec f = function
++      | key :: x ->
++          let* _ = set ~dbg ~sr ~vdi ~key:(_vdi_tags_key ^ key) ~value:key in
++          f x
++      | [] ->
++          return ()
++    in
++    f vdi_info.tags >>>= fun () ->
+     let response =
+       {
+         (vdi_of_volume response) with
+diff --git a/ocaml/xapi/storage_smapiv1_migrate.ml b/ocaml/xapi/storage_smapiv1_migrate.ml
+index b201813d8..b8d43ee79 100644
+--- a/ocaml/xapi/storage_smapiv1_migrate.ml
++++ b/ocaml/xapi/storage_smapiv1_migrate.ml
+@@ -650,6 +650,11 @@ module MIRROR : SMAPIv2_MIRROR = struct
+             add_to_sm_config vdi_info "image-format" fmt
+       in
+       let leaf = SMAPI.VDI.create dbg sr vdi_info in
++
++      List.iter
++        (fun tag -> Local.VDI.add_tags dbg sr leaf.vdi tag)
++        vdi_info.tags ;
++
+       D.info "Created leaf VDI for mirror receive: %s" (string_of_vdi_info leaf) ;
+       on_fail := (fun () -> SMAPI.VDI.destroy dbg sr leaf.vdi) :: !on_fail ;
+       (* dummy VDI is created so that the leaf VDI becomes a differencing disk,

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -28,7 +28,7 @@
 Summary: xapi - xen toolstack for XCP
 Name:    xapi
 Version: 26.1.16
-Release: 1%{?xsrel}.1%{?dist}
+Release: 1%{?xsrel}.2%{?dist}
 Group:   System/Hypervisor
 License: LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception
 URL:  http://www.xen.org
@@ -116,7 +116,9 @@ Patch1013: 0013-CA-428532-Ensure-db-flush-is-executed-in-shutdown_ag.patch
 # Exclude linstor SRs from QCOW2 quicktests
 Patch1014: 0014-quicktest-Exclude-linstor-SRs-from-QCOW2-quicktests.patch
 
-
+Patch1015: 0015-ocaml-libs-Move-Vhd_qcow_parsing-into-a-library-outs.patch
+Patch1016: 0016-vhd-tool-Add-a-hybridqcow-mode.patch
+Patch1017: 0017-quicktest-Add-VDI.pool_migrate-tests-to-vdi_ops_data.patch
 
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
@@ -1521,6 +1523,9 @@ Coverage files from unit tests
 %{?_cov_results_package}
 
 %changelog
+* Wed Aug 19 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.16-1.2
+- Optimize migration from QCOW2-backed VDIs
+
 * Fri Aug 07 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.16-1.1
 - Exclude linstor SRs from QCOW2 quicktests
 - Ensure the xapi database is flushed when shutting down

--- a/SPECS/xapi.spec
+++ b/SPECS/xapi.spec
@@ -120,6 +120,11 @@ Patch1015: 0015-ocaml-libs-Move-Vhd_qcow_parsing-into-a-library-outs.patch
 Patch1016: 0016-vhd-tool-Add-a-hybridqcow-mode.patch
 Patch1017: 0017-quicktest-Add-VDI.pool_migrate-tests-to-vdi_ops_data.patch
 
+# In v26.1.20 upstream
+Patch1018: 0018-storage-Add-tags-to-vdi_info-struct.patch
+Patch1019: 0019-storage-Add-VDI.-add_tags-remove_tags-methods.patch
+Patch1020: 0020-storage-Preserve-VDI-tags-on-SMAPIv1-migrate.patch
+
 %{?_cov_buildrequires}
 BuildRequires: ocaml-ocamldoc
 BuildRequires: pam-devel
@@ -1525,6 +1530,7 @@ Coverage files from unit tests
 %changelog
 * Wed Aug 19 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.16-1.2
 - Optimize migration from QCOW2-backed VDIs
+- Preserve VDI tags on migration
 
 * Fri Aug 07 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 26.1.16-1.1
 - Exclude linstor SRs from QCOW2 quicktests


### PR DESCRIPTION
sparse_dd now consults the map of allocated clusters for QCOW2-backed VDIs, which greatly improves migration performance.

These patches have not been posted upstream yet - I would like to run them through our CI first.

New quicktests are added as well - I've verified they pass.

Also backport patches to preserve VDI tags on migration

### Main information

#### Work Item Reference

XCPNG-3671 and XCPNG-3319

#### Context & Motivation

Migration from QCOW2-backed VDIs is extremely inefficient and slow, this improves performance for sparse VDIs significantly.

Kubernetes integration requires VDIs to have some persistent information to track them across migrations, VDI tags were chosen for this purpose.

#### Release Target

- [ ] We already defined a release target with the release team.
- [X] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

- Optimize migration from QCOW2-backed VDIs
- Preserve VDI tags on migration

#### Attention points

None

#### Documentation update needed

- [X] No

---

### Testing and regression avoidance

Regular CI is enough - it covers VM migration for different image formats.

#### What tests have you performed?

Manual performance testing, ran the new quicktests. Manually verified VDI tags are preserved on migration.

#### What manual tests should be performed after the build, and by whom?

None

#### What's covered by the xcp-ng-tests test suite?

xcp-ng-tests does not test `VDI.pool_migrate`, but it does test `VM.migrate` extensively. We need to make sure migration tests (with integrity checks) are done from QCOW2 VDIs.

#### What tests have been or will be added to CI for this change? If none, explain why.

A new quicktest has been added verifying disk integrity after `VDI.pool_migrate` from qcow2 and vhd.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [X] No